### PR TITLE
📦 Weekly Package Upgrade (2026-05-03)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.14/schema.json",
   "assist": {
     "actions": {
       "source": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "rss": "^1.2.2",
     "storybook": "^10.3.6",
     "tsparticles": "^3.9.1",
-    "vercel": "^52.0.0"
+    "vercel": "^53.1.0"
   },
   "devDependencies": {
     "@babel/core": "^7.29.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@types/react-dom": "^19.2.3",
     "@types/react-scroll": "^1.8.10",
     "babel-loader": "^10.1.1",
-    "chromatic": "^16.6.0",
+    "chromatic": "^16.6.3",
     "husky": "^9.1.7",
     "hygen": "^6.2.11",
     "jest": "^30.3.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "react-icons": "^5.6.0",
     "react-scroll": "^1.9.3",
     "rss": "^1.2.2",
-    "storybook": "^10.3.5",
+    "storybook": "^10.3.6",
     "tsparticles": "^3.9.1",
     "vercel": "^52.0.0"
   },
@@ -26,7 +26,7 @@
     "@babel/core": "^7.29.0",
     "@biomejs/biome": "^2.4.14",
     "@chromatic-com/storybook": "^5.1.2",
-    "@storybook/nextjs": "^10.3.5",
+    "@storybook/nextjs": "^10.3.6",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.29.0",
-    "@biomejs/biome": "^2.4.13",
+    "@biomejs/biome": "^2.4.14",
     "@chromatic-com/storybook": "^5.1.2",
     "@storybook/nextjs": "^10.3.5",
     "@testing-library/dom": "^10.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6065,11 +6065,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vercel/backends@npm:0.2.0":
-  version: 0.2.0
-  resolution: "@vercel/backends@npm:0.2.0"
+"@vercel/backends@npm:0.3.0":
+  version: 0.3.0
+  resolution: "@vercel/backends@npm:0.3.0"
   dependencies:
-    "@vercel/build-utils": "npm:13.20.0"
+    "@vercel/build-utils": "npm:13.21.0"
     "@vercel/nft": "npm:1.5.0"
     "@yarnpkg/parsers": "npm:^3.0.0"
     execa: "npm:3.2.0"
@@ -6084,7 +6084,7 @@ __metadata:
     zod: "npm:3.22.4"
   peerDependencies:
     typescript: ^4.0.0 || ^5.0.0
-  checksum: d2fcb56787bb730e209869e513deb994b22a0fdeb1dad8500a0ac526520d567b4f099d7474a6923720fd09ab8e8d4e69f01e337612d732194f8a237a746c56c3
+  checksum: 44fedcaa4ffee80d55c2d5600841327829fbb7cf8c7b06d7fe1bd562696d78ee80aa1631f502b26eac28f875030a5e268c90a5d5022430d9f5bdd8ed99f9c01b
   languageName: node
   linkType: hard
 
@@ -6101,27 +6101,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vercel/build-utils@npm:13.20.0":
-  version: 13.20.0
-  resolution: "@vercel/build-utils@npm:13.20.0"
+"@vercel/build-utils@npm:13.21.0":
+  version: 13.21.0
+  resolution: "@vercel/build-utils@npm:13.21.0"
   dependencies:
-    "@vercel/python-analysis": "npm:0.11.0"
+    "@vercel/python-analysis": "npm:0.11.1"
     cjs-module-lexer: "npm:1.2.3"
     es-module-lexer: "npm:1.5.0"
-  checksum: efcd0ca6cca2ebcaa6ada34a4f2caadae18e4e8a1605a8a8a7a19514787043607eb3652e542509a821a4de3aa77d74e6c45deee8a65d01ceeea92b908d29ceba
+  checksum: a7f31519873dafb651abf5fe7fa203120a091a8e145ad2861a0be1f05a1eacf130abaf84b15328fc9ad958e9dbbfec102207950f30aeaaef3e7f7d1897058050
   languageName: node
   linkType: hard
 
-"@vercel/cervel@npm:0.0.55":
-  version: 0.0.55
-  resolution: "@vercel/cervel@npm:0.0.55"
+"@vercel/cervel@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@vercel/cervel@npm:0.1.0"
   dependencies:
-    "@vercel/backends": "npm:0.2.0"
+    "@vercel/backends": "npm:0.3.0"
   peerDependencies:
     typescript: ^4.0.0 || ^5.0.0
   bin:
     cervel: bin/cervel.mjs
-  checksum: 62af6f496b74229b92f3ee8ed576bba78d5a3cae94f780221e7d0b319683c59cc9004db91894c9c1d958f69bc8516f8d342e1e9e3b5836fa3a1bccc37ec56937
+  checksum: 1542a3dd314b1a0480a9a52d30f4d6120cdde880eab8fe0a84eaa0000be54d07180060f039e689da703f48205d834bc576997d0f2035b9a0afca5331b92cb80f
   languageName: node
   linkType: hard
 
@@ -6132,46 +6132,46 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vercel/elysia@npm:0.1.71":
-  version: 0.1.71
-  resolution: "@vercel/elysia@npm:0.1.71"
+"@vercel/elysia@npm:0.1.73":
+  version: 0.1.73
+  resolution: "@vercel/elysia@npm:0.1.73"
   dependencies:
-    "@vercel/node": "npm:5.7.13"
-    "@vercel/static-config": "npm:3.2.0"
-  checksum: 5a1f88e9a1337e21443920dcb70f9273e42afe718aa15ac71317b18dc69ac52592a8dd75fa4ae406ac559b54a8156011fd9d78aaeec04c1c106acf8a15e35d30
+    "@vercel/node": "npm:5.7.15"
+    "@vercel/static-config": "npm:3.3.0"
+  checksum: d8b0383ac224942e94960a233771dfedef91e350308ce2e5b176c5d53936786403cc1bab6410c37c63b948d73d7dc5f8ec9dccea29c041b798c10e048099677f
   languageName: node
   linkType: hard
 
-"@vercel/error-utils@npm:2.0.3":
-  version: 2.0.3
-  resolution: "@vercel/error-utils@npm:2.0.3"
-  checksum: e9f417b097bd2bcb53fe2e04060b07ec51a74bf835a07dc0616d08448d1a4365286a550e84b041462c718e83a82350aebe3a7e61811fdf13879b560d00a43f32
+"@vercel/error-utils@npm:2.1.0":
+  version: 2.1.0
+  resolution: "@vercel/error-utils@npm:2.1.0"
+  checksum: ba67eca29ffd1d9a57ff67294cddd24dfce2f23983811086b3e7b5d3bff1ba121985bae7a4327a3eda4b14f692c50bcccf4d1dbdffdbae996caa9163fbc6e422
   languageName: node
   linkType: hard
 
-"@vercel/express@npm:0.1.81":
-  version: 0.1.81
-  resolution: "@vercel/express@npm:0.1.81"
+"@vercel/express@npm:0.1.83":
+  version: 0.1.83
+  resolution: "@vercel/express@npm:0.1.83"
   dependencies:
-    "@vercel/cervel": "npm:0.0.55"
+    "@vercel/cervel": "npm:0.1.0"
     "@vercel/nft": "npm:1.5.0"
-    "@vercel/node": "npm:5.7.13"
-    "@vercel/static-config": "npm:3.2.0"
+    "@vercel/node": "npm:5.7.15"
+    "@vercel/static-config": "npm:3.3.0"
     fs-extra: "npm:11.1.0"
     path-to-regexp: "npm:8.3.0"
     ts-morph: "npm:12.0.0"
     zod: "npm:3.22.4"
-  checksum: 1751863ceb7807e9abbdc4c9a887190d404612070b8f9d197bdd91ae89fcbce33a75d58f40a41cdb6dd7348469a0b818eb3ca8474776975aa6c3ca9f53c28ab1
+  checksum: ced1b5827138f6fc95b906eee36b78b321306c38bf2117041f6239f5d29e175659acfa9ea3adf9f25358cdab1187967b62df3ff252d4b06ba7a38abb34a00b4c
   languageName: node
   linkType: hard
 
-"@vercel/fastify@npm:0.1.74":
-  version: 0.1.74
-  resolution: "@vercel/fastify@npm:0.1.74"
+"@vercel/fastify@npm:0.1.76":
+  version: 0.1.76
+  resolution: "@vercel/fastify@npm:0.1.76"
   dependencies:
-    "@vercel/node": "npm:5.7.13"
-    "@vercel/static-config": "npm:3.2.0"
-  checksum: 7bc772aa50f075b7caa76a821852e1b959e5cb4f7530a1269325b4be5c8b4a051b3baccfabc11d80ad89ee9d2e9d4e59e3c2cf34b58bb0c6eaf9629ba0949678
+    "@vercel/node": "npm:5.7.15"
+    "@vercel/static-config": "npm:3.3.0"
+  checksum: b980c0209ffaafec02fcfe5cb9faafc2f14153c61fc4c22fa518e7bc5c41d72d5a00f87ab4bce4d7b43c89555b3deb19da48b4557e0a8f3d131b6c643f760927
   languageName: node
   linkType: hard
 
@@ -6210,87 +6210,87 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vercel/gatsby-plugin-vercel-builder@npm:2.1.21":
-  version: 2.1.21
-  resolution: "@vercel/gatsby-plugin-vercel-builder@npm:2.1.21"
+"@vercel/gatsby-plugin-vercel-builder@npm:2.2.0":
+  version: 2.2.0
+  resolution: "@vercel/gatsby-plugin-vercel-builder@npm:2.2.0"
   dependencies:
     "@sinclair/typebox": "npm:0.25.24"
-    "@vercel/build-utils": "npm:13.20.0"
+    "@vercel/build-utils": "npm:13.21.0"
     esbuild: "npm:0.27.0"
     etag: "npm:1.8.1"
     fs-extra: "npm:11.1.0"
-  checksum: 82a9656829e1098b28e3463f7fa79c0732ff859c4d50a1ab3adbe75083d9aff767af6ac7aaea59a2b5a8793f042b9879dd02347463c7d1858a851d25f6770b37
+  checksum: e5f893d6f89e77e3389ed952fca54634a26f7204d50d56c19790e52a493904134df25162a870dc8a8cadeb170ca4cc5a975508837d87bc032a1663db8e292932
   languageName: node
   linkType: hard
 
-"@vercel/go@npm:3.5.0":
-  version: 3.5.0
-  resolution: "@vercel/go@npm:3.5.0"
-  checksum: 189e382c91a3adf60334d80556b42fd64c3b4fa5389c6e5ae0d0c85bb04af79bb20c4409f2949847f3ba145636de251abcf8b58951f40ab3964c09cafa191aa9
+"@vercel/go@npm:3.6.0":
+  version: 3.6.0
+  resolution: "@vercel/go@npm:3.6.0"
+  checksum: 41cdd918454cbff2a0964bc11183b3e4c3129cbeac876f15f7ac3c98e0b5b783d822726e6e85fa962e3e14fcc6b46e69cce935f215f8d86884701c2c02e4c987
   languageName: node
   linkType: hard
 
-"@vercel/h3@npm:0.1.80":
-  version: 0.1.80
-  resolution: "@vercel/h3@npm:0.1.80"
+"@vercel/h3@npm:0.1.82":
+  version: 0.1.82
+  resolution: "@vercel/h3@npm:0.1.82"
   dependencies:
-    "@vercel/node": "npm:5.7.13"
-    "@vercel/static-config": "npm:3.2.0"
-  checksum: 63a28c55e24c4785b7acf30c9474d9c78811641c58fe71f32814ec743e099fafb036b0dec20c6f2c7c02cbee4164c449bc882494fd87f111dcbb16e43dbe129f
+    "@vercel/node": "npm:5.7.15"
+    "@vercel/static-config": "npm:3.3.0"
+  checksum: 6707955e27fdde0977cdb21de6c03eedd61ffbe15bc61a6c00737756641b85cc6e3e4f6e265aef39468c8a1f0ee2058d6ef5bbba250a404f5db347f7954e8f70
   languageName: node
   linkType: hard
 
-"@vercel/hono@npm:0.2.74":
-  version: 0.2.74
-  resolution: "@vercel/hono@npm:0.2.74"
+"@vercel/hono@npm:0.2.76":
+  version: 0.2.76
+  resolution: "@vercel/hono@npm:0.2.76"
   dependencies:
     "@vercel/nft": "npm:1.5.0"
-    "@vercel/node": "npm:5.7.13"
-    "@vercel/static-config": "npm:3.2.0"
+    "@vercel/node": "npm:5.7.15"
+    "@vercel/static-config": "npm:3.3.0"
     fs-extra: "npm:11.1.0"
     path-to-regexp: "npm:8.3.0"
     ts-morph: "npm:12.0.0"
     zod: "npm:3.22.4"
-  checksum: 750e8e5e73aed662b07a9c27418b8e8a176f68b9f36038e311487ce0e92de4ede6bc70fce0b806f56e61c788dd041e8364b1a7f31f2180b831bdce80277f57af
+  checksum: 670dfa00ad122644e83dfbd786bd5c35556fddfd8cc744529075a3f76a5f5987259061739a2dbf980099f530ee49840669bb3e3596edd83ff928f0baaad26d12
   languageName: node
   linkType: hard
 
-"@vercel/hydrogen@npm:1.3.6":
-  version: 1.3.6
-  resolution: "@vercel/hydrogen@npm:1.3.6"
+"@vercel/hydrogen@npm:1.3.7":
+  version: 1.3.7
+  resolution: "@vercel/hydrogen@npm:1.3.7"
   dependencies:
-    "@vercel/static-config": "npm:3.2.0"
+    "@vercel/static-config": "npm:3.3.0"
     ts-morph: "npm:12.0.0"
-  checksum: 2085e72c8a8e36d0448ad8f088e0d2b5a55a48605ba9442d7bb4853ae3d303a46a9fd09ec0df6970d5c12ae5bfdff0e999a907ef2c2169f15997aa9b9ee81103
+  checksum: df13bf6d7a4c95d7ffea0554185ff57719246f06347c3ebc72d4b826560cac2b6f900223a657f1562b446748fe06f20900678bcb61b6598ec3c11a0770e48f29
   languageName: node
   linkType: hard
 
-"@vercel/koa@npm:0.1.54":
-  version: 0.1.54
-  resolution: "@vercel/koa@npm:0.1.54"
+"@vercel/koa@npm:0.1.56":
+  version: 0.1.56
+  resolution: "@vercel/koa@npm:0.1.56"
   dependencies:
-    "@vercel/node": "npm:5.7.13"
-    "@vercel/static-config": "npm:3.2.0"
-  checksum: cf3b55216857af91d57f3092e9ab0c53d339ab8a56fbed62c1f48891ebcd629cfe0bc7191d0dfc58ba9012ee419b30eaf37b4235deb0d2bd950b0a09c951c32a
+    "@vercel/node": "npm:5.7.15"
+    "@vercel/static-config": "npm:3.3.0"
+  checksum: 5091b91ea92bfa2de9cc58d449804404fe74d28099e3d6bda3c062acf9929bfc385c2f6881026a251842754bac26a13b23906797d64098e16e8c2dbb973220b8
   languageName: node
   linkType: hard
 
-"@vercel/nestjs@npm:0.2.75":
-  version: 0.2.75
-  resolution: "@vercel/nestjs@npm:0.2.75"
+"@vercel/nestjs@npm:0.2.77":
+  version: 0.2.77
+  resolution: "@vercel/nestjs@npm:0.2.77"
   dependencies:
-    "@vercel/node": "npm:5.7.13"
-    "@vercel/static-config": "npm:3.2.0"
-  checksum: 2008719ab805d6045f5a699eebb4a423fbc7e1ff9d666f22d8f54e7911ad89a720415e2b5d36f2907e3cf348a2a182436041bdf10d4971f7589a0848d3768fb1
+    "@vercel/node": "npm:5.7.15"
+    "@vercel/static-config": "npm:3.3.0"
+  checksum: a1c67b5a9929706980c9f26fe3687a3a8221535ff84decbd8de523db9c3ed5a71c9e30d60c33d5369313276f60fc13419bbb55002f7b19529ab527b77f14c9a6
   languageName: node
   linkType: hard
 
-"@vercel/next@npm:4.16.8":
-  version: 4.16.8
-  resolution: "@vercel/next@npm:4.16.8"
+"@vercel/next@npm:4.17.0":
+  version: 4.17.0
+  resolution: "@vercel/next@npm:4.17.0"
   dependencies:
     "@vercel/nft": "npm:1.5.0"
-  checksum: 9926b8e71dc1288401d6e27e49a8d3a5d3861e7bb1a502c83f247e7f595d100eff3a64634a6951782908cbd26851097cd441b7bf467614cd7d8895fedfff63d7
+  checksum: c5432e969e4b455751f78991a43511b8228ebe06198d46eb922704b17ea2f28bc2d8d1db2b3dbee41fbaf15b31a3efd3ed7eab9d2def3b1382dc07f7691feac4
   languageName: node
   linkType: hard
 
@@ -6316,18 +6316,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vercel/node@npm:5.7.13":
-  version: 5.7.13
-  resolution: "@vercel/node@npm:5.7.13"
+"@vercel/node@npm:5.7.15":
+  version: 5.7.15
+  resolution: "@vercel/node@npm:5.7.15"
   dependencies:
     "@edge-runtime/node-utils": "npm:2.3.0"
     "@edge-runtime/primitives": "npm:4.1.0"
     "@edge-runtime/vm": "npm:3.2.0"
     "@types/node": "npm:20.11.0"
-    "@vercel/build-utils": "npm:13.20.0"
-    "@vercel/error-utils": "npm:2.0.3"
+    "@vercel/build-utils": "npm:13.21.0"
+    "@vercel/error-utils": "npm:2.1.0"
     "@vercel/nft": "npm:1.5.0"
-    "@vercel/static-config": "npm:3.2.0"
+    "@vercel/static-config": "npm:3.3.0"
     async-listen: "npm:3.0.0"
     cjs-module-lexer: "npm:1.2.3"
     edge-runtime: "npm:2.5.9"
@@ -6342,7 +6342,7 @@ __metadata:
     tsx: "npm:4.21.0"
     typescript: "npm:typescript@5.9.3"
     undici: "npm:5.28.4"
-  checksum: 5d6bb74434cb3b94ad968b0e5a6eeba31eddab9591fad511ad3dc819e25fc79462562069ed1f6315d5008ede6b5fbe877153e1482a41b71b3e9c3051ded46d8d
+  checksum: df202a22d509d1e10c8101376c7b9763a8ca58ec60e526bac9bcc8a43c61bf30e94283908f7e4c39154a03729d97d05ac8ce09edf7ddaa4344afd38df2b3173d
   languageName: node
   linkType: hard
 
@@ -6360,9 +6360,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vercel/python-analysis@npm:0.11.0":
-  version: 0.11.0
-  resolution: "@vercel/python-analysis@npm:0.11.0"
+"@vercel/python-analysis@npm:0.11.1":
+  version: 0.11.1
+  resolution: "@vercel/python-analysis@npm:0.11.1"
   dependencies:
     "@bytecodealliance/preview2-shim": "npm:0.17.6"
     "@renovatebot/pep440": "npm:4.2.1"
@@ -6371,42 +6371,42 @@ __metadata:
     minimatch: "npm:10.1.1"
     smol-toml: "npm:1.5.2"
     zod: "npm:3.22.4"
-  checksum: 427f347f75de1daf07a01cfc6ca3baea012cdbccb176dcf04a725c942e4ea8556bea82421dddb2e03620c62fad00098acffe71e74683140d429589fbc34d9c19
+  checksum: d57fc0a71dc04664468f9fa40e14407f834317e73c91b940cd32bf068a588aaa99d2367d9ad760e591c49db5762a38aa952d78ff7ca0a11b9664561740be8138
   languageName: node
   linkType: hard
 
-"@vercel/python@npm:6.36.0":
-  version: 6.36.0
-  resolution: "@vercel/python@npm:6.36.0"
+"@vercel/python@npm:6.37.0":
+  version: 6.37.0
+  resolution: "@vercel/python@npm:6.37.0"
   dependencies:
-    "@vercel/python-analysis": "npm:0.11.0"
-  checksum: ccf86d613da0a496b8f8f2c244a9fa2bbe05fc6107555c7bc8dbbb2f0024dc6f4f5cabace7f701c6b3c6b7578dd6f98f80aac1530ca6511ad78a3da28c9a22ff
+    "@vercel/python-analysis": "npm:0.11.1"
+  checksum: 924a0c51020e4e98de4a400eb6b206c40ea42b36a839a41bf7323cafcf32868e353051146435d4adfd0bcb1fd24e3f762b28b0c5adf49f3055bc6f8264508110
   languageName: node
   linkType: hard
 
-"@vercel/redwood@npm:2.4.12":
-  version: 2.4.12
-  resolution: "@vercel/redwood@npm:2.4.12"
+"@vercel/redwood@npm:2.4.13":
+  version: 2.4.13
+  resolution: "@vercel/redwood@npm:2.4.13"
   dependencies:
     "@vercel/nft": "npm:1.5.0"
-    "@vercel/static-config": "npm:3.2.0"
+    "@vercel/static-config": "npm:3.3.0"
     semver: "npm:6.3.1"
     ts-morph: "npm:12.0.0"
-  checksum: 090083f632eb2d0c6e30c9cecde75400d9233490dbe6461f38d07148d80057a9e6b1c5d5e2a686f5e92472fa2da29225bdf49e2298e018d7a8f4dfd829fbd35d
+  checksum: 280f03d20e08ac318b9dbb4a481113da34a2462c08bd4950130a5c2086efff3b00272b76fdaee3624c534630c96ac197ff4208d287fe6ed3ee7b6a0b17a90d44
   languageName: node
   linkType: hard
 
-"@vercel/remix-builder@npm:5.7.2":
-  version: 5.7.2
-  resolution: "@vercel/remix-builder@npm:5.7.2"
+"@vercel/remix-builder@npm:5.8.0":
+  version: 5.8.0
+  resolution: "@vercel/remix-builder@npm:5.8.0"
   dependencies:
-    "@vercel/error-utils": "npm:2.0.3"
+    "@vercel/error-utils": "npm:2.1.0"
     "@vercel/nft": "npm:1.5.0"
-    "@vercel/static-config": "npm:3.2.0"
+    "@vercel/static-config": "npm:3.3.0"
     path-to-regexp: "npm:6.1.0"
     path-to-regexp-updated: "npm:path-to-regexp@6.3.0"
     ts-morph: "npm:12.0.0"
-  checksum: c7b9aa00dfcdc1a4ff91b0ebc6f2e7ada8c795875822895ea515da74875abeb3c4379acc1c055dc7b09c9bdf6b4529d7f559c18b03ae391c76ff93c3ed05c960
+  checksum: e01196770f0673ccd04cf9d7e0462a2e599ffd010f2d2c6f592c48496c82f4f19a00f0ba6f2f9e7282a244167a3bc7dbcbdcc4abda263c14504ae6e526028985
   languageName: node
   linkType: hard
 
@@ -6417,13 +6417,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vercel/rust@npm:1.1.1":
-  version: 1.1.1
-  resolution: "@vercel/rust@npm:1.1.1"
+"@vercel/rust@npm:1.2.0":
+  version: 1.2.0
+  resolution: "@vercel/rust@npm:1.2.0"
   dependencies:
     execa: "npm:5"
     smol-toml: "npm:1.5.2"
-  checksum: 3bb9a31b3c3d6a96df2d3fd91d111c347d4b6dfa99e0de54e9f4b9a480720cfdc5d411906262e82830efabf1e578c40fa6fe3cde4c1c1129b84984819fc197fc
+  checksum: 9dc16849dbfb856f4f730e0412f7a153e7b8c330a926a50187a80ff8c2172e8da73799dd74896d74b65c021402093df7189e14e7bb8192c9a406b3d153d6704a
   languageName: node
   linkType: hard
 
@@ -6474,26 +6474,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vercel/static-build@npm:2.9.21":
-  version: 2.9.21
-  resolution: "@vercel/static-build@npm:2.9.21"
+"@vercel/static-build@npm:2.9.22":
+  version: 2.9.22
+  resolution: "@vercel/static-build@npm:2.9.22"
   dependencies:
     "@vercel/gatsby-plugin-vercel-analytics": "npm:1.0.11"
-    "@vercel/gatsby-plugin-vercel-builder": "npm:2.1.21"
-    "@vercel/static-config": "npm:3.2.0"
+    "@vercel/gatsby-plugin-vercel-builder": "npm:2.2.0"
+    "@vercel/static-config": "npm:3.3.0"
     ts-morph: "npm:12.0.0"
-  checksum: e4ce002c7e6aaba9ecbcf3216bdcbb9e41fa14c8394f69873b844f39cb73fcdb8dbca56a19cfd5b0da153846278a291a06fc83724864a72872eb1f633e9e7211
+  checksum: 07ac60440879f55236740e2e9772dcad0edd5f5be16633d128b090441b2e4c736e9e79344e6b268df67105a54d299d5f009042167fbf31c25c2f6ab2002fb2f5
   languageName: node
   linkType: hard
 
-"@vercel/static-config@npm:3.2.0":
-  version: 3.2.0
-  resolution: "@vercel/static-config@npm:3.2.0"
+"@vercel/static-config@npm:3.3.0":
+  version: 3.3.0
+  resolution: "@vercel/static-config@npm:3.3.0"
   dependencies:
     ajv: "npm:8.6.3"
     json-schema-to-ts: "npm:1.6.4"
     ts-morph: "npm:12.0.0"
-  checksum: e3823339da3bcf140f03667dff9c1ce9601f165ee6422199a7f8e0d48ed6e10cb3d56544671116aa021e44ce2dda5c0860f7bb9a8444e458e101f26acf58bd5f
+  checksum: 2eba816cad840e9dd5a3798233eef6a878c4eb6400b74313ef58c27ab637d3eb2c590001f80588f60f011fbe174f424ae138de8d70b518e50b2b51021091ccbc
   languageName: node
   linkType: hard
 
@@ -12592,7 +12592,7 @@ __metadata:
     tsconfig-paths-webpack-plugin: "npm:^4.2.0"
     tsparticles: "npm:^3.9.1"
     typescript: "npm:^6.0.3"
-    vercel: "npm:^52.0.0"
+    vercel: "npm:^53.1.0"
     vite: "npm:^8.0.10"
   languageName: unknown
   linkType: soft
@@ -16427,33 +16427,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vercel@npm:^52.0.0":
-  version: 52.0.0
-  resolution: "vercel@npm:52.0.0"
+"vercel@npm:^53.1.0":
+  version: 53.1.0
+  resolution: "vercel@npm:53.1.0"
   dependencies:
-    "@vercel/backends": "npm:0.2.0"
+    "@vercel/backends": "npm:0.3.0"
     "@vercel/blob": "npm:2.3.0"
-    "@vercel/build-utils": "npm:13.20.0"
+    "@vercel/build-utils": "npm:13.21.0"
     "@vercel/detect-agent": "npm:1.2.3"
-    "@vercel/elysia": "npm:0.1.71"
-    "@vercel/express": "npm:0.1.81"
-    "@vercel/fastify": "npm:0.1.74"
+    "@vercel/elysia": "npm:0.1.73"
+    "@vercel/express": "npm:0.1.83"
+    "@vercel/fastify": "npm:0.1.76"
     "@vercel/fun": "npm:1.3.0"
-    "@vercel/go": "npm:3.5.0"
-    "@vercel/h3": "npm:0.1.80"
-    "@vercel/hono": "npm:0.2.74"
-    "@vercel/hydrogen": "npm:1.3.6"
-    "@vercel/koa": "npm:0.1.54"
-    "@vercel/nestjs": "npm:0.2.75"
-    "@vercel/next": "npm:4.16.8"
-    "@vercel/node": "npm:5.7.13"
+    "@vercel/go": "npm:3.6.0"
+    "@vercel/h3": "npm:0.1.82"
+    "@vercel/hono": "npm:0.2.76"
+    "@vercel/hydrogen": "npm:1.3.7"
+    "@vercel/koa": "npm:0.1.56"
+    "@vercel/nestjs": "npm:0.2.77"
+    "@vercel/next": "npm:4.17.0"
+    "@vercel/node": "npm:5.7.15"
     "@vercel/prepare-flags-definitions": "npm:0.2.1"
-    "@vercel/python": "npm:6.36.0"
-    "@vercel/redwood": "npm:2.4.12"
-    "@vercel/remix-builder": "npm:5.7.2"
+    "@vercel/python": "npm:6.37.0"
+    "@vercel/redwood": "npm:2.4.13"
+    "@vercel/remix-builder": "npm:5.8.0"
     "@vercel/ruby": "npm:2.3.2"
-    "@vercel/rust": "npm:1.1.1"
-    "@vercel/static-build": "npm:2.9.21"
+    "@vercel/rust": "npm:1.2.0"
+    "@vercel/static-build": "npm:2.9.22"
     chokidar: "npm:4.0.0"
     esbuild: "npm:0.27.0"
     form-data: "npm:^4.0.0"
@@ -16465,7 +16465,7 @@ __metadata:
   bin:
     vc: dist/vc.js
     vercel: dist/vc.js
-  checksum: c186d0cee1ca87a25d1da0d54aa8a8da05bfa5818a539cb9f30c1acb9bd5234a098ed5a88e06b4f16f6a3d425214784dd7cd455cb5e115a782224f928628a551
+  checksum: 6af10654a76a09330f3d32452352bc3f2a440f20ec599282a6fceaad431ca3e12edd079da4110f44f82b62d2e7c8d0d76dd07e7cf090c94dfdc144ef27686bcb
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7965,9 +7965,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chromatic@npm:^16.6.0":
-  version: 16.6.0
-  resolution: "chromatic@npm:16.6.0"
+"chromatic@npm:^16.6.3":
+  version: 16.6.3
+  resolution: "chromatic@npm:16.6.3"
   dependencies:
     semver: "npm:^7.3.5"
   peerDependencies:
@@ -7985,7 +7985,7 @@ __metadata:
     chroma: dist/bin.cjs
     chromatic: dist/bin.cjs
     chromatic-cli: dist/bin.cjs
-  checksum: 27f905e3d8cc1a865e354b0a09ac533daea1a5be0e60f82ae489cda5e5c5d2ff773a749bd5e904cf712ca040d19561e0c4e7877d3e49e32f7010c50b0a94346f
+  checksum: a27b46dbef9935892f36f672e49ece11cfbe0e64bf52d09948a69bf687f26b45f17fc2da6b1c50c00bb3aca1545efe7b9fd96bbc8f1ba901e8768a8c19940d0f
   languageName: node
   linkType: hard
 
@@ -12570,7 +12570,7 @@ __metadata:
     "@vercel/speed-insights": "npm:2.0.0"
     babel-loader: "npm:^10.1.1"
     cheerio: "npm:^1.2.0"
-    chromatic: "npm:^16.6.0"
+    chromatic: "npm:^16.6.3"
     highlight.js: "npm:^11.11.1"
     husky: "npm:^9.1.7"
     hygen: "npm:^6.2.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2165,18 +2165,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@biomejs/biome@npm:^2.4.13":
-  version: 2.4.13
-  resolution: "@biomejs/biome@npm:2.4.13"
+"@biomejs/biome@npm:^2.4.14":
+  version: 2.4.14
+  resolution: "@biomejs/biome@npm:2.4.14"
   dependencies:
-    "@biomejs/cli-darwin-arm64": "npm:2.4.13"
-    "@biomejs/cli-darwin-x64": "npm:2.4.13"
-    "@biomejs/cli-linux-arm64": "npm:2.4.13"
-    "@biomejs/cli-linux-arm64-musl": "npm:2.4.13"
-    "@biomejs/cli-linux-x64": "npm:2.4.13"
-    "@biomejs/cli-linux-x64-musl": "npm:2.4.13"
-    "@biomejs/cli-win32-arm64": "npm:2.4.13"
-    "@biomejs/cli-win32-x64": "npm:2.4.13"
+    "@biomejs/cli-darwin-arm64": "npm:2.4.14"
+    "@biomejs/cli-darwin-x64": "npm:2.4.14"
+    "@biomejs/cli-linux-arm64": "npm:2.4.14"
+    "@biomejs/cli-linux-arm64-musl": "npm:2.4.14"
+    "@biomejs/cli-linux-x64": "npm:2.4.14"
+    "@biomejs/cli-linux-x64-musl": "npm:2.4.14"
+    "@biomejs/cli-win32-arm64": "npm:2.4.14"
+    "@biomejs/cli-win32-x64": "npm:2.4.14"
   dependenciesMeta:
     "@biomejs/cli-darwin-arm64":
       optional: true
@@ -2196,62 +2196,62 @@ __metadata:
       optional: true
   bin:
     biome: bin/biome
-  checksum: a8c09d7c05d834243a76704e31bda05346d2a06a75e90e6de2ef0d4edc33bd7d382b380bad9275ddd379e9e44ceaea9907a9c0de2156859b36b057c155f20a0e
+  checksum: 83a42fc27cf74b66f5035fd38c23292c51506cb28181aeb2c3b22a289c265ede011d85876aaed85cc378c8c937a3ed27d99030f356ecebb2de42550627b089c8
   languageName: node
   linkType: hard
 
-"@biomejs/cli-darwin-arm64@npm:2.4.13":
-  version: 2.4.13
-  resolution: "@biomejs/cli-darwin-arm64@npm:2.4.13"
+"@biomejs/cli-darwin-arm64@npm:2.4.14":
+  version: 2.4.14
+  resolution: "@biomejs/cli-darwin-arm64@npm:2.4.14"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@biomejs/cli-darwin-x64@npm:2.4.13":
-  version: 2.4.13
-  resolution: "@biomejs/cli-darwin-x64@npm:2.4.13"
+"@biomejs/cli-darwin-x64@npm:2.4.14":
+  version: 2.4.14
+  resolution: "@biomejs/cli-darwin-x64@npm:2.4.14"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@biomejs/cli-linux-arm64-musl@npm:2.4.13":
-  version: 2.4.13
-  resolution: "@biomejs/cli-linux-arm64-musl@npm:2.4.13"
+"@biomejs/cli-linux-arm64-musl@npm:2.4.14":
+  version: 2.4.14
+  resolution: "@biomejs/cli-linux-arm64-musl@npm:2.4.14"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@biomejs/cli-linux-arm64@npm:2.4.13":
-  version: 2.4.13
-  resolution: "@biomejs/cli-linux-arm64@npm:2.4.13"
+"@biomejs/cli-linux-arm64@npm:2.4.14":
+  version: 2.4.14
+  resolution: "@biomejs/cli-linux-arm64@npm:2.4.14"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@biomejs/cli-linux-x64-musl@npm:2.4.13":
-  version: 2.4.13
-  resolution: "@biomejs/cli-linux-x64-musl@npm:2.4.13"
+"@biomejs/cli-linux-x64-musl@npm:2.4.14":
+  version: 2.4.14
+  resolution: "@biomejs/cli-linux-x64-musl@npm:2.4.14"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@biomejs/cli-linux-x64@npm:2.4.13":
-  version: 2.4.13
-  resolution: "@biomejs/cli-linux-x64@npm:2.4.13"
+"@biomejs/cli-linux-x64@npm:2.4.14":
+  version: 2.4.14
+  resolution: "@biomejs/cli-linux-x64@npm:2.4.14"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@biomejs/cli-win32-arm64@npm:2.4.13":
-  version: 2.4.13
-  resolution: "@biomejs/cli-win32-arm64@npm:2.4.13"
+"@biomejs/cli-win32-arm64@npm:2.4.14":
+  version: 2.4.14
+  resolution: "@biomejs/cli-win32-arm64@npm:2.4.14"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@biomejs/cli-win32-x64@npm:2.4.13":
-  version: 2.4.13
-  resolution: "@biomejs/cli-win32-x64@npm:2.4.13"
+"@biomejs/cli-win32-x64@npm:2.4.14":
+  version: 2.4.14
+  resolution: "@biomejs/cli-win32-x64@npm:2.4.14"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -12551,7 +12551,7 @@ __metadata:
   resolution: "miyulab-officialsite@workspace:."
   dependencies:
     "@babel/core": "npm:^7.29.0"
-    "@biomejs/biome": "npm:^2.4.13"
+    "@biomejs/biome": "npm:^2.4.14"
     "@chromatic-com/storybook": "npm:^5.1.2"
     "@storybook/nextjs": "npm:^10.3.5"
     "@testing-library/dom": "npm:^10.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4297,11 +4297,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/builder-webpack5@npm:10.3.5":
-  version: 10.3.5
-  resolution: "@storybook/builder-webpack5@npm:10.3.5"
+"@storybook/builder-webpack5@npm:10.3.6":
+  version: 10.3.6
+  resolution: "@storybook/builder-webpack5@npm:10.3.6"
   dependencies:
-    "@storybook/core-webpack": "npm:10.3.5"
+    "@storybook/core-webpack": "npm:10.3.6"
     case-sensitive-paths-webpack-plugin: "npm:^2.4.0"
     cjs-module-lexer: "npm:^1.2.3"
     css-loader: "npm:^7.1.2"
@@ -4317,22 +4317,22 @@ __metadata:
     webpack-hot-middleware: "npm:^2.25.1"
     webpack-virtual-modules: "npm:^0.6.0"
   peerDependencies:
-    storybook: ^10.3.5
+    storybook: ^10.3.6
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 71d3c95acb79c05c14742a74845a3f2a13ef87477ff95a35665709ca7b4399edb79525637eb2b3bf0742d9e88cf46104a8a5ef4308e28b72bdbf91431a79839c
+  checksum: 947eaed5fdbea48d0eaa4225a229e8edc1e31fa4de02f7cd91e73ad9a67858ea82fa59e88f4edda42c5b75e210d18e36273e9d6c089a9952a10aa902e630f37f
   languageName: node
   linkType: hard
 
-"@storybook/core-webpack@npm:10.3.5":
-  version: 10.3.5
-  resolution: "@storybook/core-webpack@npm:10.3.5"
+"@storybook/core-webpack@npm:10.3.6":
+  version: 10.3.6
+  resolution: "@storybook/core-webpack@npm:10.3.6"
   dependencies:
     ts-dedent: "npm:^2.0.0"
   peerDependencies:
-    storybook: ^10.3.5
-  checksum: 384b453c1bdd49fe9c4eef6e8e783ae239cce1c9e4fa6e5f1a9cb46ab50868c3cdb8e66cf993a7cfd925154ff3d1322a0a4c23571fc98ca10f6f5d1272e33768
+    storybook: ^10.3.6
+  checksum: d667cc293e020f1d4559cae9742d514df55563472c9d3421588d0608bfd42c50a0bd67cd24a4228b0fcb24fb8d6fa4c35733e087b693b103502165189006dfb0
   languageName: node
   linkType: hard
 
@@ -4353,9 +4353,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/nextjs@npm:^10.3.5":
-  version: 10.3.5
-  resolution: "@storybook/nextjs@npm:10.3.5"
+"@storybook/nextjs@npm:^10.3.6":
+  version: 10.3.6
+  resolution: "@storybook/nextjs@npm:10.3.6"
   dependencies:
     "@babel/core": "npm:^7.28.5"
     "@babel/plugin-syntax-bigint": "npm:^7.8.3"
@@ -4371,9 +4371,9 @@ __metadata:
     "@babel/preset-typescript": "npm:^7.28.5"
     "@babel/runtime": "npm:^7.28.4"
     "@pmmmwh/react-refresh-webpack-plugin": "npm:^0.5.11"
-    "@storybook/builder-webpack5": "npm:10.3.5"
-    "@storybook/preset-react-webpack": "npm:10.3.5"
-    "@storybook/react": "npm:10.3.5"
+    "@storybook/builder-webpack5": "npm:10.3.6"
+    "@storybook/preset-react-webpack": "npm:10.3.6"
+    "@storybook/react": "npm:10.3.6"
     "@types/semver": "npm:^7.7.1"
     babel-loader: "npm:^9.1.3"
     css-loader: "npm:^6.7.3"
@@ -4394,22 +4394,22 @@ __metadata:
     next: ^14.1.0 || ^15.0.0 || ^16.0.0
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-    storybook: ^10.3.5
+    storybook: ^10.3.6
     webpack: ^5.0.0
   peerDependenciesMeta:
     typescript:
       optional: true
     webpack:
       optional: true
-  checksum: 736ad4d25ee0b8b4cba116ff10c9e89aef0f7c6285fc808ea6b487e9103bbd559589c7ca84142b03571b105f1a8afa3fbd699568c1a3b60cdf9567f4ca7c8816
+  checksum: dbf51738d47f6c454b568cf6f73ff4f91764ef78f206c14544084e4f6b5361b169082163acda44859de470eab9381ed0e893a99a53cfc778d07b3da87cd0af05
   languageName: node
   linkType: hard
 
-"@storybook/preset-react-webpack@npm:10.3.5":
-  version: 10.3.5
-  resolution: "@storybook/preset-react-webpack@npm:10.3.5"
+"@storybook/preset-react-webpack@npm:10.3.6":
+  version: 10.3.6
+  resolution: "@storybook/preset-react-webpack@npm:10.3.6"
   dependencies:
-    "@storybook/core-webpack": "npm:10.3.5"
+    "@storybook/core-webpack": "npm:10.3.6"
     "@storybook/react-docgen-typescript-plugin": "npm:1.0.6--canary.9.0c3f3b7.0"
     "@types/semver": "npm:^7.7.1"
     magic-string: "npm:^0.30.5"
@@ -4421,11 +4421,11 @@ __metadata:
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-    storybook: ^10.3.5
+    storybook: ^10.3.6
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: deb87bab231b595094f048e59f03638d0a0efcfac1274cc1bc7f95a03fa5ae84b3afe1cf5551183098081569f35ee3b9827c5b3d7c811b7e2824a786f44f4976
+  checksum: 94df7549a55d814fca1dda23d25552a3ba2ade5f152950235ea14a489913be4bd1cfedf4295cb0c077dc41b7e47e4512216fdb22af62edf1e4ec4316ae149629
   languageName: node
   linkType: hard
 
@@ -4447,34 +4447,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@storybook/react-dom-shim@npm:10.3.5":
-  version: 10.3.5
-  resolution: "@storybook/react-dom-shim@npm:10.3.5"
+"@storybook/react-dom-shim@npm:10.3.6":
+  version: 10.3.6
+  resolution: "@storybook/react-dom-shim@npm:10.3.6"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-    storybook: ^10.3.5
-  checksum: 53383a37a4507dbdb088bebb402f259126d678d63d4b83186b794192e8a8d6528852b223d8bd7f98645293e5f99cf5feb11bfa14e441a47de92d42d3aa04ecdb
+    storybook: ^10.3.6
+  checksum: 60183fc05b0410ca174f215d3271ffbccdc2680bd0704f58dc931cf60e72f497a9f22c00afa868398ad693c7ec633ef619541d4b0611fc2a577fb09609fcc3c7
   languageName: node
   linkType: hard
 
-"@storybook/react@npm:10.3.5":
-  version: 10.3.5
-  resolution: "@storybook/react@npm:10.3.5"
+"@storybook/react@npm:10.3.6":
+  version: 10.3.6
+  resolution: "@storybook/react@npm:10.3.6"
   dependencies:
     "@storybook/global": "npm:^5.0.0"
-    "@storybook/react-dom-shim": "npm:10.3.5"
+    "@storybook/react-dom-shim": "npm:10.3.6"
     react-docgen: "npm:^8.0.2"
     react-docgen-typescript: "npm:^2.2.2"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-    storybook: ^10.3.5
+    storybook: ^10.3.6
     typescript: ">= 4.9.x"
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 708460a9f8055dfe8c86f383222f6e17484138537a317e3dcc457b578686302a0bfb566f3c921cba1bfcbd2378405046a360808b2d78601875cf6066d5dd4930
+  checksum: 3d3af66105cdca98c537b4bcc3e92f87e3b56d154b24e9b167300e9d5de8a7ba6a5ef3c22203ccb6f4c2f0602a5546273b2b49728aa383ba0f98e66a286647a8
   languageName: node
   linkType: hard
 
@@ -12553,7 +12553,7 @@ __metadata:
     "@babel/core": "npm:^7.29.0"
     "@biomejs/biome": "npm:^2.4.14"
     "@chromatic-com/storybook": "npm:^5.1.2"
-    "@storybook/nextjs": "npm:^10.3.5"
+    "@storybook/nextjs": "npm:^10.3.6"
     "@testing-library/dom": "npm:^10.4.1"
     "@testing-library/jest-dom": "npm:6.9.1"
     "@testing-library/react": "npm:^16.3.2"
@@ -12587,7 +12587,7 @@ __metadata:
     react-scroll: "npm:^1.9.3"
     rss: "npm:^1.2.2"
     sass: "npm:^1.99.0"
-    storybook: "npm:^10.3.5"
+    storybook: "npm:^10.3.6"
     storybook-dark-mode: "npm:^5.0.0"
     tsconfig-paths-webpack-plugin: "npm:^4.2.0"
     tsparticles: "npm:^3.9.1"
@@ -15261,9 +15261,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"storybook@npm:^10.3.5":
-  version: 10.3.5
-  resolution: "storybook@npm:10.3.5"
+"storybook@npm:^10.3.6":
+  version: 10.3.6
+  resolution: "storybook@npm:10.3.6"
   dependencies:
     "@storybook/global": "npm:^5.0.0"
     "@storybook/icons": "npm:^2.0.1"
@@ -15280,12 +15280,15 @@ __metadata:
     ws: "npm:^8.18.0"
   peerDependencies:
     prettier: ^2 || ^3
+    vite-plus: ^0.1.15
   peerDependenciesMeta:
     prettier:
       optional: true
+    vite-plus:
+      optional: true
   bin:
     storybook: ./dist/bin/dispatcher.js
-  checksum: 1443e4710b0bb972db7704d8445c039a6335afafebe853d2b0d89b161262050cd7ae5eda3811c771d54d832f0acc80cf2c231d24f73d1f547d020898394afde6
+  checksum: ee6702667459ba2d49269ddd63a7281f17816fcdd4bacd338ed47a4a8e7ad65760c90d99f6b2dfdfd0a564bcfcab3c1ea05b50bf3aafc6b5b19a039a5da77870
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Upgraded the following npm packages:

| Package | From | To | Type |
|---|---|---|---|
| `@biomejs/biome` | ^2.4.13 | ^2.4.14 | patch |
| `chromatic` | ^16.6.0 | ^16.6.3 | patch |
| `storybook` | ^10.3.5 | ^10.3.6 | patch |
| `@storybook/nextjs` | ^10.3.5 | ^10.3.6 | patch |
| `vercel` | ^52.0.0 | ^53.1.0 | major |

## Details

- **`@biomejs/biome` 2.4.14**: Ran `yarn biome migrate --write` to update the schema version in `biome.json`, then `yarn check:fix` to apply formatting.
- **chromatic 16.6.3**: Patch update, no code changes required.
- **storybook + `@storybook/nextjs` 10.3.6**: Patch update, no code changes required.
- **vercel 53.1.0**: Major version bump (52 → 53), build and lint checks passed without any code changes required.

## Verification

All upgrades passed:
- ✅ `yarn check:fix` — No issues
- ✅ `yarn check` — No issues  
- ✅ `yarn build` — Build successful

## Skipped Packages

No packages were skipped. All outdated packages were successfully upgraded.




> Generated by [📦 Weekly Package Upgrade Agent](https://github.com/WakuwakuP/miyulab-officialsite/actions/runs/25292137677)
> - [x] expires <!-- gh-aw-expires: 2026-05-10T22:14:23.678Z --> on May 10, 2026, 10:14 PM UTC

<!-- gh-aw-agentic-workflow: 📦 Weekly Package Upgrade Agent, engine: copilot, id: 25292137677, workflow_id: weekly-package-upgrade, run: https://github.com/WakuwakuP/miyulab-officialsite/actions/runs/25292137677 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: weekly-package-upgrade -->