### PR TITLE
fix(ci): use pull_request instead of pull_request_target

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -3,7 +3,7 @@ name: Lint & Format
 on:
   push:
     branches: [main, master, develop]
-  pull_request_target:
+  pull_request:
     branches: [main, master, develop]
 
 jobs:
@@ -13,8 +13,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - run: corepack enable yarn
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,10 @@ jobs:
 
       - name: Comment test coverage
         uses: davelosert/vitest-coverage-report-action@v2
-        if: github.event_name == 'pull_request'
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
         with:
           json-summary-path: "./coverage/coverage-summary.json"
           json-final-path: "./coverage/coverage-final.json"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test
 on:
   push:
     branches: [main, master, develop]
-  pull_request_target:
+  pull_request:
     branches: [main, master, develop]
 
 jobs:
@@ -17,8 +17,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - run: corepack enable yarn
 
@@ -36,7 +34,7 @@ jobs:
 
       - name: Comment test coverage
         uses: davelosert/vitest-coverage-report-action@v2
-        if: github.event_name == 'pull_request_target'
+        if: github.event_name == 'pull_request'
         with:
           json-summary-path: "./coverage/coverage-summary.json"
           json-final-path: "./coverage/coverage-final.json"


### PR DESCRIPTION
## Summary
- `pull_request_target` を `pull_request` に変更し、PR 由来のコードをベースリポジトリ権限で実行しないようにした
- PR head の明示 checkout を削除（`pull_request` ではデフォルトのマージコミット checkout で十分）
- カバレッジコメントの条件を `pull_request` イベントに合わせて更新

## Test plan
- [ ] この PR で Test / Lint & Format ワークフローが成功すること
- [ ] カバレッジレポートが PR にコメントされること（同一リポジトリ PR）