### PR TITLE
📦 Weekly Package Upgrade (2026-05-31)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "hygen": "^6.2.11",
     "jest": "^30.4.2",
     "jest-environment-jsdom": "^30.4.1",
-    "lint-staged": "^17.0.5",
+    "lint-staged": "^17.0.7",
     "sass": "^1.100.0",
     "storybook": "^10.4.1",
     "storybook-dark-mode": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "storybook-dark-mode": "^5.0.0",
     "tsconfig-paths-webpack-plugin": "^4.2.0",
     "typescript": "^6.0.3",
-    "vercel": "^54.4.1",
+    "vercel": "^54.6.1",
     "vite": "^8.0.14"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.29.0",
-    "@biomejs/biome": "^2.4.15",
+    "@biomejs/biome": "^2.4.16",
     "@chromatic-com/storybook": "^5.2.1",
     "@storybook/nextjs": "^10.4.1",
     "@testing-library/dom": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@types/react-dom": "^19.2.3",
     "@types/react-scroll": "^1.8.10",
     "babel-loader": "^10.1.1",
-    "chromatic": "^17.0.0",
+    "chromatic": "^17.1.0",
     "husky": "^9.1.7",
     "hygen": "^6.2.11",
     "jest": "^30.4.2",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "tsparticles": "^3.9.1"
   },
   "devDependencies": {
-    "@babel/core": "^7.29.0",
+    "@babel/core": "^7.29.7",
     "@biomejs/biome": "^2.4.16",
     "@chromatic-com/storybook": "^5.2.1",
     "@storybook/nextjs": "^10.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12210,21 +12210,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lint-staged@npm:^17.0.5":
-  version: 17.0.5
-  resolution: "lint-staged@npm:17.0.5"
+"lint-staged@npm:^17.0.7":
+  version: 17.0.7
+  resolution: "lint-staged@npm:17.0.7"
   dependencies:
     listr2: "npm:^10.2.1"
     picomatch: "npm:^4.0.4"
     string-argv: "npm:^0.3.2"
-    tinyexec: "npm:^1.1.2"
-    yaml: "npm:^2.8.4"
+    tinyexec: "npm:^1.2.4"
+    yaml: "npm:^2.9.0"
   dependenciesMeta:
     yaml:
       optional: true
   bin:
     lint-staged: bin/lint-staged.js
-  checksum: 6ecf2024744147ea768dbd550c0c47f04b295f07d30e5ecb5e375c18d8fc24d4bfa897042f4aabd7c3510054ad5bbbb51fa36e60e8dca853e31f9876ef9a3726
+  checksum: c4e7100becb327d817999a231b8d345e6be389c555d9cd8d668797d2670832ad15c4e5085b61895e3fbf937f0fbd6be5c78ca76a4599ed332227f37270ebe8eb
   languageName: node
   linkType: hard
 
@@ -12879,7 +12879,7 @@ __metadata:
     hygen: "npm:^6.2.11"
     jest: "npm:^30.4.2"
     jest-environment-jsdom: "npm:^30.4.1"
-    lint-staged: "npm:^17.0.5"
+    lint-staged: "npm:^17.0.7"
     microcms-js-sdk: "npm:^3.4.0"
     microcms-richedit-processer: "npm:^1.2.0"
     next: "npm:^16.2.6"
@@ -16243,10 +16243,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tinyexec@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "tinyexec@npm:1.1.2"
-  checksum: 9e0ef6c001ce54688cf16833a02f70a339276219ca947b88930b124267de2cffc764ff44e87e7369384b1d75ab63491465412cbbdf06f2437956b9ab66ab4491
+"tinyexec@npm:^1.2.4":
+  version: 1.2.4
+  resolution: "tinyexec@npm:1.2.4"
+  checksum: 153b8db6b080194b558ff145b9cffc36b80a6e07babd644dcfbe49c807eee668c876049d28bdee90b96304476f883352f2dad91b3f86bc23832532f4363e66ff
   languageName: node
   linkType: hard
 
@@ -17396,12 +17396,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:^2.8.4":
-  version: 2.8.4
-  resolution: "yaml@npm:2.8.4"
+"yaml@npm:^2.9.0":
+  version: 2.9.0
+  resolution: "yaml@npm:2.9.0"
   bin:
     yaml: bin.mjs
-  checksum: 0a33a1fa28d4bc79f61a12ec7ef7a2bce0ce5f8e80c6eaecfb4a0c88c08767dd1ede372b6a3bcd70891213b8c9f3169b355c97e77026d3b3459e10d2cccaef1e
+  checksum: f340718df45e97a9551b9bf9dac61c80050bc464513b710debfb5067c380c8472e3b67809cffacb4ab5ffb5e66ef9310816c88b05f371cec60abfedd8c88e0a2
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6558,14 +6558,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vercel/backends@npm:0.7.2":
-  version: 0.7.2
-  resolution: "@vercel/backends@npm:0.7.2"
+"@vercel/backends@npm:0.8.3":
+  version: 0.8.3
+  resolution: "@vercel/backends@npm:0.8.3"
   dependencies:
-    "@vercel/build-utils": "npm:13.26.1"
-    "@vercel/nft": "npm:1.5.0"
+    "@vercel/build-utils": "npm:13.26.4"
+    "@vercel/nft": "npm:1.10.0"
     execa: "npm:3.2.0"
     fs-extra: "npm:11.1.0"
+    get-port: "npm:5.1.1"
     oxc-transform: "npm:0.111.0"
     path-to-regexp: "npm:8.3.0"
     resolve.exports: "npm:2.0.3"
@@ -6573,7 +6574,7 @@ __metadata:
     srvx: "npm:0.8.9"
     tsx: "npm:4.21.0"
     zod: "npm:3.22.4"
-  checksum: ac01b68899c9b30f4de1067f1083a030dd61f53aad59bb2eaac90c2ef92f87b50a80179b04bf55a918d2cf8c9435b40eaa41d3fae87d317d3e68795239933bfd
+  checksum: aea00fcbc6324e5f18c2561e743b2116de891ff13a09d7b6e35d92d36e18ec862217cdb62b37527151556ba51cdd85559b61af5978f52a215dfc44607d46ae2c
   languageName: node
   linkType: hard
 
@@ -6590,25 +6591,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vercel/build-utils@npm:13.26.1":
-  version: 13.26.1
-  resolution: "@vercel/build-utils@npm:13.26.1"
+"@vercel/build-utils@npm:13.26.4":
+  version: 13.26.4
+  resolution: "@vercel/build-utils@npm:13.26.4"
   dependencies:
     "@vercel/python-analysis": "npm:0.11.1"
     cjs-module-lexer: "npm:1.2.3"
     es-module-lexer: "npm:1.5.0"
-  checksum: e738f6dcce165aa24f46ac497363cd2e8a6db1a31df0f444a2aa7e92b4dccbf2e5d7b152c8527eba69f9085afbaccf2bed4fe35cec35e82862440c041383e7c1
+  checksum: 7328b95be9c12f6a135def47151ab505039391ecf7df9f04f91495ad875dec202b0d4f8fc0dca8064c081a49b7b2e202efa383ec26ad9c5561fa09b81042134b
   languageName: node
   linkType: hard
 
-"@vercel/cervel@npm:0.1.7":
-  version: 0.1.7
-  resolution: "@vercel/cervel@npm:0.1.7"
+"@vercel/cervel@npm:0.1.11":
+  version: 0.1.11
+  resolution: "@vercel/cervel@npm:0.1.11"
   dependencies:
-    "@vercel/backends": "npm:0.7.2"
+    "@vercel/backends": "npm:0.8.3"
   bin:
     cervel: bin/cervel.mjs
-  checksum: 6e137a560066d4d678112c6a034ce8bd56c2a2e6f77aaa6687b227f4d3aa43d4b83cb109569f889177e33afc959b9ad61ec22cea49f2fce1a89e6a0772abdae2
+  checksum: 65c63546de66796597b33c3941a1bcc7dfa2f86daf64a37ea630928b37936b95ba342c297bdc6e0c226aff2c08b8192c6f77b4f51be9d44693978b75fd937aa2
   languageName: node
   linkType: hard
 
@@ -6629,13 +6630,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vercel/elysia@npm:0.1.80":
-  version: 0.1.80
-  resolution: "@vercel/elysia@npm:0.1.80"
+"@vercel/elysia@npm:0.1.84":
+  version: 0.1.84
+  resolution: "@vercel/elysia@npm:0.1.84"
   dependencies:
-    "@vercel/node": "npm:5.8.4"
-    "@vercel/static-config": "npm:3.3.0"
-  checksum: 6c002e85b85c237c472c89d6ded2ce90859599d764c1906ad9fedd4e209d4038829506aca2f5c43818f0208afec545790f4db85fa7c2fd545c6e96cc873eb92b
+    "@vercel/node": "npm:5.8.8"
+    "@vercel/static-config": "npm:3.4.0"
+  checksum: 04995c342952410f88660944d8f3bc10523cc2c61e1f712e7d590ef9436b3f07fca0b337f61c409791ae6c8a1fc8e243dd39597631c19bcf603ce3872e788348
   languageName: node
   linkType: hard
 
@@ -6646,29 +6647,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vercel/express@npm:0.1.90":
-  version: 0.1.90
-  resolution: "@vercel/express@npm:0.1.90"
+"@vercel/express@npm:0.1.94":
+  version: 0.1.94
+  resolution: "@vercel/express@npm:0.1.94"
   dependencies:
-    "@vercel/cervel": "npm:0.1.7"
-    "@vercel/nft": "npm:1.5.0"
-    "@vercel/node": "npm:5.8.4"
-    "@vercel/static-config": "npm:3.3.0"
+    "@vercel/cervel": "npm:0.1.11"
+    "@vercel/nft": "npm:1.10.0"
+    "@vercel/node": "npm:5.8.8"
+    "@vercel/static-config": "npm:3.4.0"
     fs-extra: "npm:11.1.0"
     path-to-regexp: "npm:8.3.0"
     ts-morph: "npm:12.0.0"
     zod: "npm:3.22.4"
-  checksum: 6bc1c9a3c0b6a39a49957cb8f298241d584663b0157285b6abf7900ca7556a4fbf697d5cc1d41fea5e79b6b603ffd4fb87ca56e267cf51a33b7762f829eb984a
+  checksum: eaece59ba049b489c2e57f157abe4221822318b7befb881964deb4e6bacd9ec17529606c84662a9e0ea83b6f8cec3b9eab59109492a9480931c7e59ce517aebd
   languageName: node
   linkType: hard
 
-"@vercel/fastify@npm:0.1.83":
-  version: 0.1.83
-  resolution: "@vercel/fastify@npm:0.1.83"
+"@vercel/fastify@npm:0.1.87":
+  version: 0.1.87
+  resolution: "@vercel/fastify@npm:0.1.87"
   dependencies:
-    "@vercel/node": "npm:5.8.4"
-    "@vercel/static-config": "npm:3.3.0"
-  checksum: a693b0b497776096d6fc411e3d1df652af9e9e0375a3f8a8fbd6fa55b7e13a726a55c3ec529c37d30371d043ebe61fc8208f8abca659d327599a1f748388f4c5
+    "@vercel/node": "npm:5.8.8"
+    "@vercel/static-config": "npm:3.4.0"
+  checksum: 5d4be5a295a93cfe92fa91858b9efeb2872d393e3340d029dac402477fdddd030661780707fcce9394f21c4adedc966f7c3e9da2442a899ec9a42006ffa3e1a1
   languageName: node
   linkType: hard
 
@@ -6707,93 +6708,93 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vercel/gatsby-plugin-vercel-builder@npm:2.2.7":
-  version: 2.2.7
-  resolution: "@vercel/gatsby-plugin-vercel-builder@npm:2.2.7"
+"@vercel/gatsby-plugin-vercel-builder@npm:2.2.10":
+  version: 2.2.10
+  resolution: "@vercel/gatsby-plugin-vercel-builder@npm:2.2.10"
   dependencies:
     "@sinclair/typebox": "npm:0.25.24"
-    "@vercel/build-utils": "npm:13.26.1"
+    "@vercel/build-utils": "npm:13.26.4"
     esbuild: "npm:0.27.0"
     etag: "npm:1.8.1"
     fs-extra: "npm:11.1.0"
-  checksum: e6c4cf67cfaeed2523efefc6bc612bebb0c1ee4b86c782b6dbc74ada9a9125d8d9bfa2a6e17dc32704cf0631e609115d522f960f07c9396af5089e5502667b20
+  checksum: 94fe3f61bd896ed12de1b431d7eb18888d6bdcd50dc235d8a9375420e1153094f9ca766a146379eedb4c380885d4271a905a5697f4d72433197c6fe64908d7c1
   languageName: node
   linkType: hard
 
-"@vercel/go@npm:3.7.1":
-  version: 3.7.1
-  resolution: "@vercel/go@npm:3.7.1"
-  checksum: 6ece1aa5e2fac67dde138171f7f660335dfd797d01b9956578556457c4a08eb037b9873bfbd89559af03a9a1ed0c6a7a332d03992c06a599237a0d8dc3cc0920
+"@vercel/go@npm:3.8.0":
+  version: 3.8.0
+  resolution: "@vercel/go@npm:3.8.0"
+  checksum: 344d24710ec1dc6af5d7e07eb8a1bc126c56fd768fbc2e600d566c09d33b6ebf5fbb1914a60327fabb7fdb4283237c12cfd8a66403b046101d34b1c7ed9d21d8
   languageName: node
   linkType: hard
 
-"@vercel/h3@npm:0.1.89":
-  version: 0.1.89
-  resolution: "@vercel/h3@npm:0.1.89"
+"@vercel/h3@npm:0.1.93":
+  version: 0.1.93
+  resolution: "@vercel/h3@npm:0.1.93"
   dependencies:
-    "@vercel/node": "npm:5.8.4"
-    "@vercel/static-config": "npm:3.3.0"
-  checksum: 2b8faa6f3572fa63148a3581b221578ee80e4f7434fe5e1599a577bdc5e44ac03d97af5be8eee0bbc2b78adaa89369d5fd73a01556260481000092c2592bb2ff
+    "@vercel/node": "npm:5.8.8"
+    "@vercel/static-config": "npm:3.4.0"
+  checksum: f5f5f21ced5aa1df77a1f976af019610ee0eb38ae4d5e69bf9e2bff1f60c55d0a8edfbf9e8afb0c64f37644709675a89ad6a68b03d97ab2a121f75036e75e1d2
   languageName: node
   linkType: hard
 
-"@vercel/hono@npm:0.2.83":
-  version: 0.2.83
-  resolution: "@vercel/hono@npm:0.2.83"
+"@vercel/hono@npm:0.2.87":
+  version: 0.2.87
+  resolution: "@vercel/hono@npm:0.2.87"
   dependencies:
-    "@vercel/nft": "npm:1.5.0"
-    "@vercel/node": "npm:5.8.4"
-    "@vercel/static-config": "npm:3.3.0"
+    "@vercel/nft": "npm:1.10.0"
+    "@vercel/node": "npm:5.8.8"
+    "@vercel/static-config": "npm:3.4.0"
     fs-extra: "npm:11.1.0"
     path-to-regexp: "npm:8.3.0"
     ts-morph: "npm:12.0.0"
     zod: "npm:3.22.4"
-  checksum: 9ec4125ddf1c3952ce5f80cfed4c2ef0e6070b1f0965cc29220efe7f488173c54836c7d25f8e4816fd51b2eee07f2c59bbd3c4eb0227206f91fb0d99bb506346
+  checksum: 14756c2151892354887ccbeb9b72800f0471e5e70d0589b9dd432abe401f8b527580bde0fb814c60c0fa4ce8bfd371f2e74eac7dcce92a1d08c1822adc272577
   languageName: node
   linkType: hard
 
-"@vercel/hydrogen@npm:1.3.7":
-  version: 1.3.7
-  resolution: "@vercel/hydrogen@npm:1.3.7"
+"@vercel/hydrogen@npm:1.3.8":
+  version: 1.3.8
+  resolution: "@vercel/hydrogen@npm:1.3.8"
   dependencies:
-    "@vercel/static-config": "npm:3.3.0"
+    "@vercel/static-config": "npm:3.4.0"
     ts-morph: "npm:12.0.0"
-  checksum: df13bf6d7a4c95d7ffea0554185ff57719246f06347c3ebc72d4b826560cac2b6f900223a657f1562b446748fe06f20900678bcb61b6598ec3c11a0770e48f29
+  checksum: b946734549b8e4431ae049af7ba78ee50730f61320b7434a3301f44d5cfe631f01eacbab6480f73de9d59bf6048105169669555b33dd66e155a495b99b600809
   languageName: node
   linkType: hard
 
-"@vercel/koa@npm:0.1.63":
-  version: 0.1.63
-  resolution: "@vercel/koa@npm:0.1.63"
+"@vercel/koa@npm:0.1.67":
+  version: 0.1.67
+  resolution: "@vercel/koa@npm:0.1.67"
   dependencies:
-    "@vercel/node": "npm:5.8.4"
-    "@vercel/static-config": "npm:3.3.0"
-  checksum: d6975dd059cc887767234b3a17dc4bad7d610e41e7fece110f9db02df4e71892dddd1bc8ebf1f3670429d66a6f46f6da7150c70f2060b89c355e115052f61aa1
+    "@vercel/node": "npm:5.8.8"
+    "@vercel/static-config": "npm:3.4.0"
+  checksum: 1c253e39af1b297f969410eaa6e28f7ddfcdce25f36c1c07b63fd2e09f6fa67094e2629f8b35fbe716943c4a14fb768b37f8bbc8bb87f8f3b650df94ec100dd4
   languageName: node
   linkType: hard
 
-"@vercel/nestjs@npm:0.2.84":
-  version: 0.2.84
-  resolution: "@vercel/nestjs@npm:0.2.84"
+"@vercel/nestjs@npm:0.2.88":
+  version: 0.2.88
+  resolution: "@vercel/nestjs@npm:0.2.88"
   dependencies:
-    "@vercel/node": "npm:5.8.4"
-    "@vercel/static-config": "npm:3.3.0"
-  checksum: 5c26a144bed2111e3bc37204753b41e7fb03f8a6b4fdcf371fc90f6ef78c46a061eb497369ffe9ea48dc73b52825503c75379e87d8a17625cbbc372e4a643d24
+    "@vercel/node": "npm:5.8.8"
+    "@vercel/static-config": "npm:3.4.0"
+  checksum: 18144c0e6d35edc9254a175cb26d056cb2e75ff15cab351acde6b41209c7637f82049f8dbf1626a4aef3ac6e343a3c528c0583c036af0cf9390488cea90b8946
   languageName: node
   linkType: hard
 
-"@vercel/next@npm:4.17.4":
-  version: 4.17.4
-  resolution: "@vercel/next@npm:4.17.4"
+"@vercel/next@npm:4.17.5":
+  version: 4.17.5
+  resolution: "@vercel/next@npm:4.17.5"
   dependencies:
-    "@vercel/nft": "npm:1.5.0"
-  checksum: 07d56f5ad91ec099d34cf8b7520972c101c3fd1f0910911c6016073042ac56378d2e2d637a77d05cf8838ec38ff366fae24a462d954b1d9cdd02b3701a4eeb33
+    "@vercel/nft": "npm:1.10.0"
+  checksum: 58a77a27323d7b64fccde5cf22fb37635f0e4380446b1b4abb2c5124a3f3d84e09ea11b672442c2e4231d1e876af4848aae5954c6ae790623a2ef1d1a1ffe422
   languageName: node
   linkType: hard
 
-"@vercel/nft@npm:1.5.0":
-  version: 1.5.0
-  resolution: "@vercel/nft@npm:1.5.0"
+"@vercel/nft@npm:1.10.0":
+  version: 1.10.0
+  resolution: "@vercel/nft@npm:1.10.0"
   dependencies:
     "@mapbox/node-pre-gyp": "npm:^2.0.0"
     "@rollup/pluginutils": "npm:^5.1.3"
@@ -6809,22 +6810,22 @@ __metadata:
     resolve-from: "npm:^5.0.0"
   bin:
     nft: out/cli.js
-  checksum: e44f2bb41908f11ece98aa5c4f33b7ff6575a5102ab2db2675f4ee74bcc62439dce4d363a393f80a677898f63f7cac5741685653ee97a924e61e75c9d5b504d6
+  checksum: 3926b405e518aac7bf0312c96a0fa2eaffac3ea97ed5abca5bbb190f30263fc79811fda191d157666827e908cf6b2ff523614e9eca6203049630cf2c384b2b8a
   languageName: node
   linkType: hard
 
-"@vercel/node@npm:5.8.4":
-  version: 5.8.4
-  resolution: "@vercel/node@npm:5.8.4"
+"@vercel/node@npm:5.8.8":
+  version: 5.8.8
+  resolution: "@vercel/node@npm:5.8.8"
   dependencies:
     "@edge-runtime/node-utils": "npm:2.3.0"
     "@edge-runtime/primitives": "npm:4.1.0"
     "@edge-runtime/vm": "npm:3.2.0"
     "@types/node": "npm:20.11.0"
-    "@vercel/build-utils": "npm:13.26.1"
+    "@vercel/build-utils": "npm:13.26.4"
     "@vercel/error-utils": "npm:2.1.0"
-    "@vercel/nft": "npm:1.5.0"
-    "@vercel/static-config": "npm:3.3.0"
+    "@vercel/nft": "npm:1.10.0"
+    "@vercel/static-config": "npm:3.4.0"
     async-listen: "npm:3.0.0"
     cjs-module-lexer: "npm:1.2.3"
     edge-runtime: "npm:2.5.9"
@@ -6839,7 +6840,7 @@ __metadata:
     tsx: "npm:4.21.0"
     typescript: "npm:typescript@5.9.3"
     undici: "npm:5.28.4"
-  checksum: 2a518bd036ed1088d8ed5e610d2125a5cc02ac6adbaa10cb2b17484240269a9ba58cd6d929f1d6aac2dfaf19076146d2ca23ad526b556073603abacbacf294a9
+  checksum: d17c71cc1a8202333df4bc268b49885912d8fd7e94f22d3ea380c07e9a78f1f67bf6f066e009fb9f5b352f3995e5cedea9f12b96afa20614d47647119ac249b2
   languageName: node
   linkType: hard
 
@@ -6872,55 +6873,55 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vercel/python@npm:6.43.1":
-  version: 6.43.1
-  resolution: "@vercel/python@npm:6.43.1"
+"@vercel/python@npm:6.44.0":
+  version: 6.44.0
+  resolution: "@vercel/python@npm:6.44.0"
   dependencies:
     "@vercel/python-analysis": "npm:0.11.1"
-  checksum: 4f57b8b0a044f59b5c9a56facf69aa91787482efdaf227acb967b1750f27103cd70b274da4817acf82f4b6e978a8f3697f62b202358e21599dd44b9b433849d9
+  checksum: f3f4601055fa0b86d3d6253d661a0c5a2fe8cdf71601c4447db7fd9a4c09ac46f8ed9fd6958a15e70dc22b695e7234fef03b836483074077d88c4045c39cfd1e
   languageName: node
   linkType: hard
 
-"@vercel/redwood@npm:2.4.13":
-  version: 2.4.13
-  resolution: "@vercel/redwood@npm:2.4.13"
+"@vercel/redwood@npm:2.4.15":
+  version: 2.4.15
+  resolution: "@vercel/redwood@npm:2.4.15"
   dependencies:
-    "@vercel/nft": "npm:1.5.0"
-    "@vercel/static-config": "npm:3.3.0"
+    "@vercel/nft": "npm:1.10.0"
+    "@vercel/static-config": "npm:3.4.0"
     semver: "npm:6.3.1"
     ts-morph: "npm:12.0.0"
-  checksum: 280f03d20e08ac318b9dbb4a481113da34a2462c08bd4950130a5c2086efff3b00272b76fdaee3624c534630c96ac197ff4208d287fe6ed3ee7b6a0b17a90d44
+  checksum: 3ae9398fb9148caecfc70963a0b1b57c739a2e8d86adba592a1cdc1131238bc968b90433a9110171e831648c0a0111dd8f4ed1dee96083bb39d116bfd6118818
   languageName: node
   linkType: hard
 
-"@vercel/remix-builder@npm:5.8.2":
-  version: 5.8.2
-  resolution: "@vercel/remix-builder@npm:5.8.2"
+"@vercel/remix-builder@npm:5.8.4":
+  version: 5.8.4
+  resolution: "@vercel/remix-builder@npm:5.8.4"
   dependencies:
     "@vercel/error-utils": "npm:2.1.0"
-    "@vercel/nft": "npm:1.5.0"
-    "@vercel/static-config": "npm:3.3.0"
+    "@vercel/nft": "npm:1.10.0"
+    "@vercel/static-config": "npm:3.4.0"
     path-to-regexp: "npm:6.1.0"
     path-to-regexp-updated: "npm:path-to-regexp@6.3.0"
     ts-morph: "npm:12.0.0"
-  checksum: 1434ef761a1353a89aaca8df41b7ecd5d83c985c9f0898a4ce5fd22190e59baebd8b164df4efd96f369e681f1ac48446e8c5f09aa8bc4b61e1c18b066a417874
+  checksum: e9c900bafff8ffc6c7357e3fb947b8190158a67658be476546c21336f76900d06e61b27340dfe4b77966ebfec55a68238e7e8aa7abc052f8b9a7cde09b00a6a6
   languageName: node
   linkType: hard
 
-"@vercel/ruby@npm:2.3.2":
-  version: 2.3.2
-  resolution: "@vercel/ruby@npm:2.3.2"
-  checksum: cf0d82cd0ceb20fbe75cdd8a8574c2ad6faccc3d18b165390719d43e522cb33248db485ea45ea3af50b5f4d34e5d6c920d208ebe95698db2a7224292cb91e629
+"@vercel/ruby@npm:2.4.0":
+  version: 2.4.0
+  resolution: "@vercel/ruby@npm:2.4.0"
+  checksum: 96e970bb8442a19af36fc606c3f03d5fbcd27f9fe3da0ce58ec4354e3317cb0b0431d4c093f814b8bd4001711d1bfb5faefac9564f62c0163666a5b02d0c9b2a
   languageName: node
   linkType: hard
 
-"@vercel/rust@npm:1.2.0":
-  version: 1.2.0
-  resolution: "@vercel/rust@npm:1.2.0"
+"@vercel/rust@npm:1.3.0":
+  version: 1.3.0
+  resolution: "@vercel/rust@npm:1.3.0"
   dependencies:
     execa: "npm:5"
     smol-toml: "npm:1.5.2"
-  checksum: 9dc16849dbfb856f4f730e0412f7a153e7b8c330a926a50187a80ff8c2172e8da73799dd74896d74b65c021402093df7189e14e7bb8192c9a406b3d153d6704a
+  checksum: b92fbd3dd5f0eeab5b2932968bbcbc79d738dff51010934823c79b3afe5240e6e14d1a141d50eee24f024cacb67c0ab65290aa74d266113b1a7189e61f7db34c
   languageName: node
   linkType: hard
 
@@ -6971,26 +6972,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vercel/static-build@npm:2.9.30":
-  version: 2.9.30
-  resolution: "@vercel/static-build@npm:2.9.30"
+"@vercel/static-build@npm:2.9.33":
+  version: 2.9.33
+  resolution: "@vercel/static-build@npm:2.9.33"
   dependencies:
     "@vercel/gatsby-plugin-vercel-analytics": "npm:1.0.11"
-    "@vercel/gatsby-plugin-vercel-builder": "npm:2.2.7"
-    "@vercel/static-config": "npm:3.3.0"
+    "@vercel/gatsby-plugin-vercel-builder": "npm:2.2.10"
+    "@vercel/static-config": "npm:3.4.0"
     ts-morph: "npm:12.0.0"
-  checksum: 8e8a66e4015c3f1aab68b2d4597e9858d352d5bea81c0e31e81a119d1e378309bcbe4b674dfd3a66844a671031308af70be1bb0997018431d0d0a94fb445c0c5
+  checksum: e94c76ace320969c328831f73c711ec5548d2f2e47da4b88dbc0883001a1301791fb7b27cf9b3beb93c5938ffc536a3e3e4f754345252f6746cfa0b42e7bb0dd
   languageName: node
   linkType: hard
 
-"@vercel/static-config@npm:3.3.0":
-  version: 3.3.0
-  resolution: "@vercel/static-config@npm:3.3.0"
+"@vercel/static-config@npm:3.4.0":
+  version: 3.4.0
+  resolution: "@vercel/static-config@npm:3.4.0"
   dependencies:
     ajv: "npm:8.6.3"
     json-schema-to-ts: "npm:1.6.4"
     ts-morph: "npm:12.0.0"
-  checksum: 2eba816cad840e9dd5a3798233eef6a878c4eb6400b74313ef58c27ab637d3eb2c590001f80588f60f011fbe174f424ae138de8d70b518e50b2b51021091ccbc
+  checksum: 22773895a10b44d453192031659d69050fdb55a60dc4a9acaa005d3609c1697e34a4b885eee5d691e7078efe8653033a473fcce8b908ff9aa7a76f4527886a88
   languageName: node
   linkType: hard
 
@@ -10603,6 +10604,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"get-port@npm:5.1.1":
+  version: 5.1.1
+  resolution: "get-port@npm:5.1.1"
+  checksum: 2873877a469b24e6d5e0be490724a17edb39fafc795d1d662e7bea951ca649713b4a50117a473f9d162312cb0e946597bd0e049ed2f866e79e576e8e213d3d1c
+  languageName: node
+  linkType: hard
+
 "get-proto@npm:^1.0.1":
   version: 1.0.1
   resolution: "get-proto@npm:1.0.1"
@@ -13047,7 +13055,7 @@ __metadata:
     tsconfig-paths-webpack-plugin: "npm:^4.2.0"
     tsparticles: "npm:^3.9.1"
     typescript: "npm:^6.0.3"
-    vercel: "npm:^54.4.1"
+    vercel: "npm:^54.6.1"
     vite: "npm:^8.0.14"
   languageName: unknown
   linkType: soft
@@ -17047,34 +17055,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vercel@npm:^54.4.1":
-  version: 54.4.1
-  resolution: "vercel@npm:54.4.1"
+"vercel@npm:^54.6.1":
+  version: 54.6.1
+  resolution: "vercel@npm:54.6.1"
   dependencies:
-    "@vercel/backends": "npm:0.7.2"
+    "@vercel/backends": "npm:0.8.3"
     "@vercel/blob": "npm:2.4.0"
-    "@vercel/build-utils": "npm:13.26.1"
+    "@vercel/build-utils": "npm:13.26.4"
     "@vercel/cli-config": "npm:0.1.2"
     "@vercel/detect-agent": "npm:1.2.3"
-    "@vercel/elysia": "npm:0.1.80"
-    "@vercel/express": "npm:0.1.90"
-    "@vercel/fastify": "npm:0.1.83"
+    "@vercel/elysia": "npm:0.1.84"
+    "@vercel/express": "npm:0.1.94"
+    "@vercel/fastify": "npm:0.1.87"
     "@vercel/fun": "npm:1.3.0"
-    "@vercel/go": "npm:3.7.1"
-    "@vercel/h3": "npm:0.1.89"
-    "@vercel/hono": "npm:0.2.83"
-    "@vercel/hydrogen": "npm:1.3.7"
-    "@vercel/koa": "npm:0.1.63"
-    "@vercel/nestjs": "npm:0.2.84"
-    "@vercel/next": "npm:4.17.4"
-    "@vercel/node": "npm:5.8.4"
+    "@vercel/go": "npm:3.8.0"
+    "@vercel/h3": "npm:0.1.93"
+    "@vercel/hono": "npm:0.2.87"
+    "@vercel/hydrogen": "npm:1.3.8"
+    "@vercel/koa": "npm:0.1.67"
+    "@vercel/nestjs": "npm:0.2.88"
+    "@vercel/next": "npm:4.17.5"
+    "@vercel/node": "npm:5.8.8"
     "@vercel/prepare-flags-definitions": "npm:0.2.1"
-    "@vercel/python": "npm:6.43.1"
-    "@vercel/redwood": "npm:2.4.13"
-    "@vercel/remix-builder": "npm:5.8.2"
-    "@vercel/ruby": "npm:2.3.2"
-    "@vercel/rust": "npm:1.2.0"
-    "@vercel/static-build": "npm:2.9.30"
+    "@vercel/python": "npm:6.44.0"
+    "@vercel/redwood": "npm:2.4.15"
+    "@vercel/remix-builder": "npm:5.8.4"
+    "@vercel/ruby": "npm:2.4.0"
+    "@vercel/rust": "npm:1.3.0"
+    "@vercel/static-build": "npm:2.9.33"
     chokidar: "npm:4.0.0"
     esbuild: "npm:0.27.0"
     form-data: "npm:^4.0.0"
@@ -17087,7 +17095,7 @@ __metadata:
   bin:
     vc: dist/vc.js
     vercel: dist/vc.js
-  checksum: a931dea4d3e2fc8e2ea3060be7d58a4560ce0b773a01a6496554c97e8398cee4419bd3f43b0051078b120013a4677506b079e674f8a224536648f41cc2ef064b
+  checksum: 6a433d1fca2dd871d63d4d148e7b24ec24280da7c1a6a4fec13860cab9b2e9e0fa49039aadc2d67da88a38eac95e12bd02a149f349eef58301e87790651314e0
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -78,6 +78,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/code-frame@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/code-frame@npm:7.29.7"
+  dependencies:
+    "@babel/helper-validator-identifier": "npm:^7.29.7"
+    js-tokens: "npm:^4.0.0"
+    picocolors: "npm:^1.1.1"
+  checksum: 169fc2080169a40c1760155eaaaf739bcb882df0bec76a83adbda5493645bc17270a3434b8848c494b1933e96fe1d147370001e3cda09a39f43ae30f08ef2069
+  languageName: node
+  linkType: hard
+
 "@babel/compat-data@npm:^7.22.9":
   version: 7.23.5
   resolution: "@babel/compat-data@npm:7.23.5"
@@ -96,6 +107,13 @@ __metadata:
   version: 7.28.6
   resolution: "@babel/compat-data@npm:7.28.6"
   checksum: 2d047431041281eaf33e9943d1a269d3374dbc9b498cafe6a18f5ee9aee7bb96f7f6cac0304eab4d13c41fc4db00fe4ca16c7aa44469ca6a211b8b6343b78fc4
+  languageName: node
+  linkType: hard
+
+"@babel/compat-data@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/compat-data@npm:7.29.7"
+  checksum: 47913f05e08a45a1c9df38c02b4b49e391005085b489432647a1abe112e5d9c75e3be8ea5972b7f6da4ec5d1339922ceb9ea02b8a25d4ed1cb8636e5261f344e
   languageName: node
   linkType: hard
 
@@ -191,26 +209,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/core@npm:^7.29.0":
-  version: 7.29.0
-  resolution: "@babel/core@npm:7.29.0"
+"@babel/core@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/core@npm:7.29.7"
   dependencies:
-    "@babel/code-frame": "npm:^7.29.0"
-    "@babel/generator": "npm:^7.29.0"
-    "@babel/helper-compilation-targets": "npm:^7.28.6"
-    "@babel/helper-module-transforms": "npm:^7.28.6"
-    "@babel/helpers": "npm:^7.28.6"
-    "@babel/parser": "npm:^7.29.0"
-    "@babel/template": "npm:^7.28.6"
-    "@babel/traverse": "npm:^7.29.0"
-    "@babel/types": "npm:^7.29.0"
+    "@babel/code-frame": "npm:^7.29.7"
+    "@babel/generator": "npm:^7.29.7"
+    "@babel/helper-compilation-targets": "npm:^7.29.7"
+    "@babel/helper-module-transforms": "npm:^7.29.7"
+    "@babel/helpers": "npm:^7.29.7"
+    "@babel/parser": "npm:^7.29.7"
+    "@babel/template": "npm:^7.29.7"
+    "@babel/traverse": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
     "@jridgewell/remapping": "npm:^2.3.5"
     convert-source-map: "npm:^2.0.0"
     debug: "npm:^4.1.0"
     gensync: "npm:^1.0.0-beta.2"
     json5: "npm:^2.2.3"
     semver: "npm:^6.3.1"
-  checksum: 5127d2e8e842ae409e11bcbb5c2dff9874abf5415e8026925af7308e903f4f43397341467a130490d1a39884f461bc2b67f3063bce0be44340db89687fd852aa
+  checksum: 112fb09c24de7a1de64d1de2c31fe65c4e6af4cb2fb6e6d99ea5373e6fc51e75b88581c0efae4c4c68f119a02a988c7106e95011a41530a2fb8ed793c7eaa07b
   languageName: node
   linkType: hard
 
@@ -291,6 +309,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/generator@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/generator@npm:7.29.7"
+  dependencies:
+    "@babel/parser": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+    "@jridgewell/gen-mapping": "npm:^0.3.12"
+    "@jridgewell/trace-mapping": "npm:^0.3.28"
+    jsesc: "npm:^3.0.2"
+  checksum: 9bf72b01b5bd0ea5b1288a0e37dbd360bff2f2b1ce73342c0d40fb3db2ec3dc004ada5ffa925c5e12939a416eed59e600d562b8ecd938ce0d27dfd0eb6c6c2b7
+  languageName: node
+  linkType: hard
+
 "@babel/helper-annotate-as-pure@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/helper-annotate-as-pure@npm:7.22.5"
@@ -345,6 +376,19 @@ __metadata:
     lru-cache: "npm:^5.1.1"
     semver: "npm:^6.3.1"
   checksum: f338fa00dcfea931804a7c55d1a1c81b6f0a09787e528ec580d5c21b3ecb3913f6cb0f361368973ce953b824d910d3ac3e8a8ee15192710d3563826447193ad1
+  languageName: node
+  linkType: hard
+
+"@babel/helper-compilation-targets@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-compilation-targets@npm:7.29.7"
+  dependencies:
+    "@babel/compat-data": "npm:^7.29.7"
+    "@babel/helper-validator-option": "npm:^7.29.7"
+    browserslist: "npm:^4.24.0"
+    lru-cache: "npm:^5.1.1"
+    semver: "npm:^6.3.1"
+  checksum: 4c15fd4c69a0a7047799a28a88460c19cede0a0ee8af994ea169114986f4af48b92c7393a4a3fee0456c11a656eece3448a6ed06354453d6c27cccf17195453b
   languageName: node
   linkType: hard
 
@@ -430,6 +474,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-globals@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-globals@npm:7.29.7"
+  checksum: f38417c40b1129a1b2b519ca961b9040c8827d1444fd74068702286b91b77089431dc76b6b9d5c1496e5da2a4f3ad329c6946e688ba3fa0d1d0b3d2b4f34f36a
+  languageName: node
+  linkType: hard
+
 "@babel/helper-hoist-variables@npm:^7.22.5":
   version: 7.22.5
   resolution: "@babel/helper-hoist-variables@npm:7.22.5"
@@ -478,6 +529,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-module-imports@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-module-imports@npm:7.29.7"
+  dependencies:
+    "@babel/traverse": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+  checksum: 6adf60d97356027413342a092f818d9678c4f5caff716a33e3284b5ae14e47a9e88059d421dde4ee4894691260039a12602c0e7becadc175602194b40dfa345d
+  languageName: node
+  linkType: hard
+
 "@babel/helper-module-transforms@npm:^7.23.3":
   version: 7.23.3
   resolution: "@babel/helper-module-transforms@npm:7.23.3"
@@ -516,6 +577,19 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0
   checksum: 549be62515a6d50cd4cfefcab1b005c47f89bd9135a22d602ee6a5e3a01f27571868ada10b75b033569f24dc4a2bb8d04bfa05ee75c16da7ade2d0db1437fcdb
+  languageName: node
+  linkType: hard
+
+"@babel/helper-module-transforms@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-module-transforms@npm:7.29.7"
+  dependencies:
+    "@babel/helper-module-imports": "npm:^7.29.7"
+    "@babel/helper-validator-identifier": "npm:^7.29.7"
+    "@babel/traverse": "npm:^7.29.7"
+  peerDependencies:
+    "@babel/core": ^7.0.0
+  checksum: ee5a2172c24a42be696836f4b0d947489c9729d8adf5821885cf77d1ad5333e3c447368e9a71f67df1099570490553dccf9f888ef0a92a48aa63cb086bd8c7e1
   languageName: node
   linkType: hard
 
@@ -617,6 +691,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-string-parser@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-string-parser@npm:7.29.7"
+  checksum: 194bc0f1716e396d5ffde56ad6119745fb9557662c98611590e5e454906783a4ccb21ce93056b8eb69a4909044834e45d96e50ac695bbe9e3221648fe033c06c
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-identifier@npm:^7.22.20":
   version: 7.22.20
   resolution: "@babel/helper-validator-identifier@npm:7.22.20"
@@ -638,6 +719,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-validator-identifier@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-validator-identifier@npm:7.29.7"
+  checksum: 4795354e7ae0dcafa72de1cd04ec51252dc1498517170beaf019e03effc5b7bf13c6b21a3949a77e07b8125be7f106ed1131350d8ebd4566ae874094a726d62b
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-option@npm:^7.22.15":
   version: 7.23.5
   resolution: "@babel/helper-validator-option@npm:7.23.5"
@@ -649,6 +737,13 @@ __metadata:
   version: 7.27.1
   resolution: "@babel/helper-validator-option@npm:7.27.1"
   checksum: 6fec5f006eba40001a20f26b1ef5dbbda377b7b68c8ad518c05baa9af3f396e780bdfded24c4eef95d14bb7b8fd56192a6ed38d5d439b97d10efc5f1a191d148
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-option@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-validator-option@npm:7.29.7"
+  checksum: d2a06c6d0ac40ba4a2f219fc2cab249c7a94bacdb2686273b7f9598571c908809b48468ff588915a346e6cc7296f60b581023d1d498b747fed06f779d335c2cc
   languageName: node
   linkType: hard
 
@@ -701,6 +796,16 @@ __metadata:
     "@babel/template": "npm:^7.28.6"
     "@babel/types": "npm:^7.28.6"
   checksum: c4a779c66396bb0cf619402d92f1610601ff3832db2d3b86b9c9dd10983bf79502270e97ac6d5280cea1b1a37de2f06ecbac561bd2271545270407fbe64027cb
+  languageName: node
+  linkType: hard
+
+"@babel/helpers@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helpers@npm:7.29.7"
+  dependencies:
+    "@babel/template": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+  checksum: 218e8d10953647c9f44775f5a022b227a182674853b5ea8631889deb7e1a3e4bc870388aaecf59bb8bd92a87f9a96220ed3f70a35bffec6bcf9169ecb67891ac
   languageName: node
   linkType: hard
 
@@ -787,6 +892,17 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: 333b2aa761264b91577a74bee86141ef733f9f9f6d4fc52548e4847dc35dfbf821f58c46832c637bfa761a6d9909d6a68f7d1ed59e17e4ffbb958dc510c17b62
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/parser@npm:7.29.7"
+  dependencies:
+    "@babel/types": "npm:^7.29.7"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 65133038f80b54a714d6027cb77cee3f9a6b5c4c6842ce674301e13947cbcbfa8055e63acaf1b84c085d34226a14425b2c2b97b829e0e226d2e8f1299942a51d
   languageName: node
   linkType: hard
 
@@ -1984,6 +2100,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/template@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/template@npm:7.29.7"
+  dependencies:
+    "@babel/code-frame": "npm:^7.29.7"
+    "@babel/parser": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+  checksum: 8bb7f900dcab0e9e1c5ffbc33ca10e0d26b7b2e2ca804becb73ee771b9c4ed6e2908a4ae4a14c08560febb45d2b6b9a173955e42ad404d05f8b04840a14d9c58
+  languageName: node
+  linkType: hard
+
 "@babel/traverse@npm:^7.18.9, @babel/traverse@npm:^7.23.5":
   version: 7.23.5
   resolution: "@babel/traverse@npm:7.23.5"
@@ -2077,6 +2204,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/traverse@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/traverse@npm:7.29.7"
+  dependencies:
+    "@babel/code-frame": "npm:^7.29.7"
+    "@babel/generator": "npm:^7.29.7"
+    "@babel/helper-globals": "npm:^7.29.7"
+    "@babel/parser": "npm:^7.29.7"
+    "@babel/template": "npm:^7.29.7"
+    "@babel/types": "npm:^7.29.7"
+    debug: "npm:^4.3.1"
+  checksum: e256a1fbdb956555b76f3c285b1e453f6bedec8b3afb61751d99d933efd11c7d79caf5ddf2493570058a9f7deaa1b48324380d7c1aa1443fd9508becbf56331a
+  languageName: node
+  linkType: hard
+
 "@babel/types@npm:^7.0.0, @babel/types@npm:^7.18.9, @babel/types@npm:^7.20.7, @babel/types@npm:^7.22.15, @babel/types@npm:^7.22.5, @babel/types@npm:^7.23.0, @babel/types@npm:^7.23.5, @babel/types@npm:^7.4.4, @babel/types@npm:^7.8.3":
   version: 7.23.5
   resolution: "@babel/types@npm:7.23.5"
@@ -2155,6 +2297,16 @@ __metadata:
     "@babel/helper-string-parser": "npm:^7.27.1"
     "@babel/helper-validator-identifier": "npm:^7.28.5"
   checksum: 23cc3466e83bcbfab8b9bd0edaafdb5d4efdb88b82b3be6728bbade5ba2f0996f84f63b1c5f7a8c0d67efded28300898a5f930b171bb40b311bca2029c4e9b4f
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/types@npm:7.29.7"
+  dependencies:
+    "@babel/helper-string-parser": "npm:^7.29.7"
+    "@babel/helper-validator-identifier": "npm:^7.29.7"
+  checksum: b6623994c69717fa27294f5fa46d59140338e2d86c6c1c13085c84ef7d53086ee357fbf4fe9abe3dd3da75734dc77c4c0df2f90fb29e667558bb3b3fb705e88f
   languageName: node
   linkType: hard
 
@@ -12853,7 +13005,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "miyulab-officialsite@workspace:."
   dependencies:
-    "@babel/core": "npm:^7.29.0"
+    "@babel/core": "npm:^7.29.7"
     "@biomejs/biome": "npm:^2.4.16"
     "@chromatic-com/storybook": "npm:^5.2.1"
     "@storybook/nextjs": "npm:^10.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8471,9 +8471,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chromatic@npm:^17.0.0":
-  version: 17.0.0
-  resolution: "chromatic@npm:17.0.0"
+"chromatic@npm:^17.1.0":
+  version: 17.1.0
+  resolution: "chromatic@npm:17.1.0"
   dependencies:
     semver: "npm:^7.3.5"
   peerDependencies:
@@ -8491,7 +8491,7 @@ __metadata:
     chroma: dist/bin.cjs
     chromatic: dist/bin.cjs
     chromatic-cli: dist/bin.cjs
-  checksum: 962c86feec17b12757fa3327b7e98abff272a048c03227bb21ecb51c7f1d7ec3589386611ece8e2c413ac4049f26d71e9c9226a5fb7628fdcbb47e87905863a0
+  checksum: 2aa6f22a444868cfaf580b54648d0397248603d0cbb35d6ac850f93400666f1d6d28fdd2a20e13865049b30d00c741b4f00c7cae7f3ca660fe43470ea3bb6a0f
   languageName: node
   linkType: hard
 
@@ -13025,7 +13025,7 @@ __metadata:
     "@vercel/speed-insights": "npm:2.0.0"
     babel-loader: "npm:^10.1.1"
     cheerio: "npm:^1.2.0"
-    chromatic: "npm:^17.0.0"
+    chromatic: "npm:^17.1.0"
     highlight.js: "npm:^11.11.1"
     husky: "npm:^9.1.7"
     hygen: "npm:^6.2.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2165,18 +2165,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@biomejs/biome@npm:^2.4.15":
-  version: 2.4.15
-  resolution: "@biomejs/biome@npm:2.4.15"
+"@biomejs/biome@npm:^2.4.16":
+  version: 2.4.16
+  resolution: "@biomejs/biome@npm:2.4.16"
   dependencies:
-    "@biomejs/cli-darwin-arm64": "npm:2.4.15"
-    "@biomejs/cli-darwin-x64": "npm:2.4.15"
-    "@biomejs/cli-linux-arm64": "npm:2.4.15"
-    "@biomejs/cli-linux-arm64-musl": "npm:2.4.15"
-    "@biomejs/cli-linux-x64": "npm:2.4.15"
-    "@biomejs/cli-linux-x64-musl": "npm:2.4.15"
-    "@biomejs/cli-win32-arm64": "npm:2.4.15"
-    "@biomejs/cli-win32-x64": "npm:2.4.15"
+    "@biomejs/cli-darwin-arm64": "npm:2.4.16"
+    "@biomejs/cli-darwin-x64": "npm:2.4.16"
+    "@biomejs/cli-linux-arm64": "npm:2.4.16"
+    "@biomejs/cli-linux-arm64-musl": "npm:2.4.16"
+    "@biomejs/cli-linux-x64": "npm:2.4.16"
+    "@biomejs/cli-linux-x64-musl": "npm:2.4.16"
+    "@biomejs/cli-win32-arm64": "npm:2.4.16"
+    "@biomejs/cli-win32-x64": "npm:2.4.16"
   dependenciesMeta:
     "@biomejs/cli-darwin-arm64":
       optional: true
@@ -2196,62 +2196,62 @@ __metadata:
       optional: true
   bin:
     biome: bin/biome
-  checksum: 46ac114b97f00e5fe0d22590337c80c7a2467d2aabf57d7f99b92356fd01cf76bb7d972782508e0f51c34e08a1a7f8e9eefec6fe72aa7b5f53b9161b7fe582e2
+  checksum: c52c4309daf241888b43912a43d1ba8bae7c2160751c33900088517da3e47d1428bb1c1f64f657efa5f42f5866e6400325b39fc41c3adf7cc7aa3f237f6fa286
   languageName: node
   linkType: hard
 
-"@biomejs/cli-darwin-arm64@npm:2.4.15":
-  version: 2.4.15
-  resolution: "@biomejs/cli-darwin-arm64@npm:2.4.15"
+"@biomejs/cli-darwin-arm64@npm:2.4.16":
+  version: 2.4.16
+  resolution: "@biomejs/cli-darwin-arm64@npm:2.4.16"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@biomejs/cli-darwin-x64@npm:2.4.15":
-  version: 2.4.15
-  resolution: "@biomejs/cli-darwin-x64@npm:2.4.15"
+"@biomejs/cli-darwin-x64@npm:2.4.16":
+  version: 2.4.16
+  resolution: "@biomejs/cli-darwin-x64@npm:2.4.16"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@biomejs/cli-linux-arm64-musl@npm:2.4.15":
-  version: 2.4.15
-  resolution: "@biomejs/cli-linux-arm64-musl@npm:2.4.15"
+"@biomejs/cli-linux-arm64-musl@npm:2.4.16":
+  version: 2.4.16
+  resolution: "@biomejs/cli-linux-arm64-musl@npm:2.4.16"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@biomejs/cli-linux-arm64@npm:2.4.15":
-  version: 2.4.15
-  resolution: "@biomejs/cli-linux-arm64@npm:2.4.15"
+"@biomejs/cli-linux-arm64@npm:2.4.16":
+  version: 2.4.16
+  resolution: "@biomejs/cli-linux-arm64@npm:2.4.16"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@biomejs/cli-linux-x64-musl@npm:2.4.15":
-  version: 2.4.15
-  resolution: "@biomejs/cli-linux-x64-musl@npm:2.4.15"
+"@biomejs/cli-linux-x64-musl@npm:2.4.16":
+  version: 2.4.16
+  resolution: "@biomejs/cli-linux-x64-musl@npm:2.4.16"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@biomejs/cli-linux-x64@npm:2.4.15":
-  version: 2.4.15
-  resolution: "@biomejs/cli-linux-x64@npm:2.4.15"
+"@biomejs/cli-linux-x64@npm:2.4.16":
+  version: 2.4.16
+  resolution: "@biomejs/cli-linux-x64@npm:2.4.16"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@biomejs/cli-win32-arm64@npm:2.4.15":
-  version: 2.4.15
-  resolution: "@biomejs/cli-win32-arm64@npm:2.4.15"
+"@biomejs/cli-win32-arm64@npm:2.4.16":
+  version: 2.4.16
+  resolution: "@biomejs/cli-win32-arm64@npm:2.4.16"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@biomejs/cli-win32-x64@npm:2.4.15":
-  version: 2.4.15
-  resolution: "@biomejs/cli-win32-x64@npm:2.4.15"
+"@biomejs/cli-win32-x64@npm:2.4.16":
+  version: 2.4.16
+  resolution: "@biomejs/cli-win32-x64@npm:2.4.16"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -12854,7 +12854,7 @@ __metadata:
   resolution: "miyulab-officialsite@workspace:."
   dependencies:
     "@babel/core": "npm:^7.29.0"
-    "@biomejs/biome": "npm:^2.4.15"
+    "@biomejs/biome": "npm:^2.4.16"
     "@chromatic-com/storybook": "npm:^5.2.1"
     "@storybook/nextjs": "npm:^10.4.1"
     "@testing-library/dom": "npm:^10.4.1"


### PR DESCRIPTION
## Summary

Automated weekly package upgrades for 2026-05-31.

## ✅ Upgraded Packages

| Package | Old Version | New Version | Type |
|---------|-------------|-------------|------|
| `@biomejs/biome` | 2.4.15 | 2.4.16 | patch |
| `lint-staged` | 17.0.5 | 17.0.7 | patch |
| `@babel/core` | 7.29.0 | 7.29.7 | patch |
| `chromatic` | 17.0.0 | 17.1.0 | minor |
| `vercel` | 54.4.1 | 54.6.1 | patch |

All upgrades passed `yarn check` and `yarn build` verification.

## ⏭️ Skipped / Reverted Packages

| Package | Current | Latest | Reason |
|---------|---------|--------|--------|
| `@tsparticles/all` | 3.9.1 | 4.1.1 | **MAJOR** – v4 has breaking changes: new peer packages required (`@tsparticles/fractal-noise`, `@tsparticles/noise-field`, `@tsparticles/perlin-noise`, `@tsparticles/simplex-noise`), and `initParticlesEngine` was removed from `@tsparticles/react`. Source code in `Particle.tsx` would need to be updated. |
| `@tsparticles/engine` | 3.9.1 | 4.1.1 | Skipped with tsparticles ecosystem (see above) |
| `@tsparticles/react` | 3.0.0 | 4.1.1 | Skipped with tsparticles ecosystem (see above) |
| `tsparticles` | 3.9.1 | 4.1.1 | Skipped with tsparticles ecosystem (see above) |




> Generated by [📦 Weekly Package Upgrade Agent](https://github.com/WakuwakuP/miyulab-officialsite/actions/runs/26725971744)
> - [x] expires <!-- gh-aw-expires: 2026-06-07T22:23:16.662Z --> on Jun 7, 2026, 10:23 PM UTC

<!-- gh-aw-agentic-workflow: 📦 Weekly Package Upgrade Agent, engine: copilot, id: 26725971744, workflow_id: weekly-package-upgrade, run: https://github.com/WakuwakuP/miyulab-officialsite/actions/runs/26725971744 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: weekly-package-upgrade -->