### PR TITLE
📦 Weekly Package Upgrade (2026-06-28)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/gtag.js": "^0.0.20",
-    "@types/node": "^26.0.0",
+    "@types/node": "^26.0.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@types/react-scroll": "^1.8.10",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "tsconfig-paths-webpack-plugin": "^4.2.0",
     "typescript": "^6.0.3",
     "vercel": "^54.18.2",
-    "vite": "^8.0.16"
+    "vite": "^8.1.0"
   },
   "lint-staged": {
     "*.{ts,tsx,js,jsx,json,css}": [

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "storybook-dark-mode": "^5.0.0",
     "tsconfig-paths-webpack-plugin": "^4.2.0",
     "typescript": "^6.0.3",
-    "vercel": "^54.14.5",
+    "vercel": "^54.18.2",
     "vite": "^8.0.16"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@types/react-dom": "^19.2.3",
     "@types/react-scroll": "^1.8.10",
     "babel-loader": "^10.1.1",
-    "chromatic": "^17.5.0",
+    "chromatic": "^17.7.2",
     "husky": "^9.1.7",
     "hygen": "^6.2.11",
     "jest": "^30.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2490,13 +2490,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emnapi/core@npm:1.10.0":
-  version: 1.10.0
-  resolution: "@emnapi/core@npm:1.10.0"
+"@emnapi/core@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@emnapi/core@npm:1.11.1"
   dependencies:
-    "@emnapi/wasi-threads": "npm:1.2.1"
+    "@emnapi/wasi-threads": "npm:1.2.2"
     tslib: "npm:^2.4.0"
-  checksum: f51d08227857b60632de7714d708124f0e100a1462dde6df8221760939aa3204a73193830371830fac0716f3ccd2129f2cac1b17cd7d7958bc4da9018a296edb
+  checksum: 2c6defdac2d1d26090384655d7d6c9614fa553853b1760597686749e9375dc2aa0dae80a2615b81c254600f5d531d07d8466cde0d331a8caae64b93f3ca5937e
   languageName: node
   linkType: hard
 
@@ -2530,12 +2530,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@emnapi/runtime@npm:1.10.0":
-  version: 1.10.0
-  resolution: "@emnapi/runtime@npm:1.10.0"
+"@emnapi/runtime@npm:1.11.1":
+  version: 1.11.1
+  resolution: "@emnapi/runtime@npm:1.11.1"
   dependencies:
     tslib: "npm:^2.4.0"
-  checksum: 953f14991d1aefb92ee6f8eb27dea725e484791a53a0cb5f47d9e0087b9a2c929ff2e92adf95af15d6ad456db6300c6b761ebf72b50a875b874a83520b3ba093
+  checksum: 04332fb62076afc440aa23316c04bec42f584ca8b074e5507d08e2b33a47cbe0493b1aadb8f3c1057b64ae1e17f5bde1a7bc37f7facc9d0bc25c18197cbd366f
   languageName: node
   linkType: hard
 
@@ -2599,6 +2599,15 @@ __metadata:
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 32fcfa81ab396533b2ec1f4082b1ff779a05d9c836bbbd3f4398405b0e6814c0d9503b7993130e37bc6941dbc1ded49f55e9700ae9ca4e803bab2b5bc5deb331
+  languageName: node
+  linkType: hard
+
+"@emnapi/wasi-threads@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@emnapi/wasi-threads@npm:1.2.2"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: f0dc8269d6b20ae5a7c7b36e7a6a333452009d461038ef4febb29da2f3f78c1e2b1576d7e8970a5c5789ed3caedc1f80f5b0c2a5373bdaf8d03b20432bb55747
   languageName: node
   linkType: hard
 
@@ -4024,6 +4033,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@napi-rs/wasm-runtime@npm:^1.1.6":
+  version: 1.1.6
+  resolution: "@napi-rs/wasm-runtime@npm:1.1.6"
+  dependencies:
+    "@tybys/wasm-util": "npm:^0.10.3"
+  peerDependencies:
+    "@emnapi/core": ^1.7.1
+    "@emnapi/runtime": ^1.7.1
+  checksum: 344518bf3ef65051dda4c00969f293aa4a21ab7dc7822b3f48519b17cd5eaa3f0bc34898d115d50ba59b1817a0cb905d46f7a7223c8249239cd14c28db388e10
+  languageName: node
+  linkType: hard
+
 "@neoconfetti/react@npm:^1.0.0":
   version: 1.0.0
   resolution: "@neoconfetti/react@npm:1.0.0"
@@ -4294,10 +4315,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@oxc-project/types@npm:=0.133.0":
-  version: 0.133.0
-  resolution: "@oxc-project/types@npm:0.133.0"
-  checksum: 70c57ba58644f7ec217b670c301801f4d06995f4ccdba6b2bd106ea3e5ee49d616573e6ef8d55530b87571a960696543687f3850e87ad173d3f88965c30cdd63
+"@oxc-project/types@npm:=0.137.0":
+  version: 0.137.0
+  resolution: "@oxc-project/types@npm:0.137.0"
+  checksum: 5a6a50174e5ac79aebf38a120fe57be7a84c8bb0c77117f30de15183aa5ab0161e78364d2d3725397090e362e5c5f6eda754b53057b0b63983e3ee604f888aca
   languageName: node
   linkType: hard
 
@@ -4793,9 +4814,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-android-arm64@npm:1.0.3":
-  version: 1.0.3
-  resolution: "@rolldown/binding-android-arm64@npm:1.0.3"
+"@rolldown/binding-android-arm64@npm:1.1.3":
+  version: 1.1.3
+  resolution: "@rolldown/binding-android-arm64@npm:1.1.3"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
@@ -4807,9 +4828,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-darwin-arm64@npm:1.0.3":
-  version: 1.0.3
-  resolution: "@rolldown/binding-darwin-arm64@npm:1.0.3"
+"@rolldown/binding-darwin-arm64@npm:1.1.3":
+  version: 1.1.3
+  resolution: "@rolldown/binding-darwin-arm64@npm:1.1.3"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
@@ -4821,9 +4842,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-darwin-x64@npm:1.0.3":
-  version: 1.0.3
-  resolution: "@rolldown/binding-darwin-x64@npm:1.0.3"
+"@rolldown/binding-darwin-x64@npm:1.1.3":
+  version: 1.1.3
+  resolution: "@rolldown/binding-darwin-x64@npm:1.1.3"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
@@ -4835,9 +4856,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-freebsd-x64@npm:1.0.3":
-  version: 1.0.3
-  resolution: "@rolldown/binding-freebsd-x64@npm:1.0.3"
+"@rolldown/binding-freebsd-x64@npm:1.1.3":
+  version: 1.1.3
+  resolution: "@rolldown/binding-freebsd-x64@npm:1.1.3"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -4849,9 +4870,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-arm-gnueabihf@npm:1.0.3":
-  version: 1.0.3
-  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.0.3"
+"@rolldown/binding-linux-arm-gnueabihf@npm:1.1.3":
+  version: 1.1.3
+  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.1.3"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
@@ -4863,9 +4884,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-arm64-gnu@npm:1.0.3":
-  version: 1.0.3
-  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.0.3"
+"@rolldown/binding-linux-arm64-gnu@npm:1.1.3":
+  version: 1.1.3
+  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.1.3"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
@@ -4877,23 +4898,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-arm64-musl@npm:1.0.3":
-  version: 1.0.3
-  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.0.3"
+"@rolldown/binding-linux-arm64-musl@npm:1.1.3":
+  version: 1.1.3
+  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.1.3"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-ppc64-gnu@npm:1.0.3":
-  version: 1.0.3
-  resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.0.3"
+"@rolldown/binding-linux-ppc64-gnu@npm:1.1.3":
+  version: 1.1.3
+  resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.1.3"
   conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-s390x-gnu@npm:1.0.3":
-  version: 1.0.3
-  resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.0.3"
+"@rolldown/binding-linux-s390x-gnu@npm:1.1.3":
+  version: 1.1.3
+  resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.1.3"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
@@ -4905,9 +4926,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-x64-gnu@npm:1.0.3":
-  version: 1.0.3
-  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.0.3"
+"@rolldown/binding-linux-x64-gnu@npm:1.1.3":
+  version: 1.1.3
+  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.1.3"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
@@ -4919,9 +4940,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-linux-x64-musl@npm:1.0.3":
-  version: 1.0.3
-  resolution: "@rolldown/binding-linux-x64-musl@npm:1.0.3"
+"@rolldown/binding-linux-x64-musl@npm:1.1.3":
+  version: 1.1.3
+  resolution: "@rolldown/binding-linux-x64-musl@npm:1.1.3"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
@@ -4933,9 +4954,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-openharmony-arm64@npm:1.0.3":
-  version: 1.0.3
-  resolution: "@rolldown/binding-openharmony-arm64@npm:1.0.3"
+"@rolldown/binding-openharmony-arm64@npm:1.1.3":
+  version: 1.1.3
+  resolution: "@rolldown/binding-openharmony-arm64@npm:1.1.3"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
@@ -4949,13 +4970,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-wasm32-wasi@npm:1.0.3":
-  version: 1.0.3
-  resolution: "@rolldown/binding-wasm32-wasi@npm:1.0.3"
+"@rolldown/binding-wasm32-wasi@npm:1.1.3":
+  version: 1.1.3
+  resolution: "@rolldown/binding-wasm32-wasi@npm:1.1.3"
   dependencies:
-    "@emnapi/core": "npm:1.10.0"
-    "@emnapi/runtime": "npm:1.10.0"
-    "@napi-rs/wasm-runtime": "npm:^1.1.4"
+    "@emnapi/core": "npm:1.11.1"
+    "@emnapi/runtime": "npm:1.11.1"
+    "@napi-rs/wasm-runtime": "npm:^1.1.6"
   conditions: cpu=wasm32
   languageName: node
   linkType: hard
@@ -4967,9 +4988,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-win32-arm64-msvc@npm:1.0.3":
-  version: 1.0.3
-  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.0.3"
+"@rolldown/binding-win32-arm64-msvc@npm:1.1.3":
+  version: 1.1.3
+  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.1.3"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
@@ -4981,9 +5002,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rolldown/binding-win32-x64-msvc@npm:1.0.3":
-  version: 1.0.3
-  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.0.3"
+"@rolldown/binding-win32-x64-msvc@npm:1.1.3":
+  version: 1.1.3
+  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.1.3"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -6365,6 +6386,15 @@ __metadata:
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: b255094f293794c6d2289300c5fbcafbb5532a3aed3a5ffd2f8dc1828e639b88d75f6a376dd8f94347a44813fd7a7149d8463477a9a49525c8b2dcaa38c2d1e8
+  languageName: node
+  linkType: hard
+
+"@tybys/wasm-util@npm:^0.10.3":
+  version: 0.10.3
+  resolution: "@tybys/wasm-util@npm:0.10.3"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: fd2bd2a79c6cd8c79ed1cf7a0fa375c64589264c88a27acaf9756d556b453ea222b62a4f68dd2fbb8b3a78b6bab3b1f4fb2431b6afc6aeda8344b53a521a1cd3
   languageName: node
   linkType: hard
 
@@ -13475,7 +13505,7 @@ __metadata:
     tsparticles: "npm:^3.9.1"
     typescript: "npm:^6.0.3"
     vercel: "npm:^54.18.2"
-    vite: "npm:^8.0.16"
+    vite: "npm:^8.1.0"
   languageName: unknown
   linkType: soft
 
@@ -15600,26 +15630,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rolldown@npm:1.0.3":
-  version: 1.0.3
-  resolution: "rolldown@npm:1.0.3"
+"rolldown@npm:~1.1.2":
+  version: 1.1.3
+  resolution: "rolldown@npm:1.1.3"
   dependencies:
-    "@oxc-project/types": "npm:=0.133.0"
-    "@rolldown/binding-android-arm64": "npm:1.0.3"
-    "@rolldown/binding-darwin-arm64": "npm:1.0.3"
-    "@rolldown/binding-darwin-x64": "npm:1.0.3"
-    "@rolldown/binding-freebsd-x64": "npm:1.0.3"
-    "@rolldown/binding-linux-arm-gnueabihf": "npm:1.0.3"
-    "@rolldown/binding-linux-arm64-gnu": "npm:1.0.3"
-    "@rolldown/binding-linux-arm64-musl": "npm:1.0.3"
-    "@rolldown/binding-linux-ppc64-gnu": "npm:1.0.3"
-    "@rolldown/binding-linux-s390x-gnu": "npm:1.0.3"
-    "@rolldown/binding-linux-x64-gnu": "npm:1.0.3"
-    "@rolldown/binding-linux-x64-musl": "npm:1.0.3"
-    "@rolldown/binding-openharmony-arm64": "npm:1.0.3"
-    "@rolldown/binding-wasm32-wasi": "npm:1.0.3"
-    "@rolldown/binding-win32-arm64-msvc": "npm:1.0.3"
-    "@rolldown/binding-win32-x64-msvc": "npm:1.0.3"
+    "@oxc-project/types": "npm:=0.137.0"
+    "@rolldown/binding-android-arm64": "npm:1.1.3"
+    "@rolldown/binding-darwin-arm64": "npm:1.1.3"
+    "@rolldown/binding-darwin-x64": "npm:1.1.3"
+    "@rolldown/binding-freebsd-x64": "npm:1.1.3"
+    "@rolldown/binding-linux-arm-gnueabihf": "npm:1.1.3"
+    "@rolldown/binding-linux-arm64-gnu": "npm:1.1.3"
+    "@rolldown/binding-linux-arm64-musl": "npm:1.1.3"
+    "@rolldown/binding-linux-ppc64-gnu": "npm:1.1.3"
+    "@rolldown/binding-linux-s390x-gnu": "npm:1.1.3"
+    "@rolldown/binding-linux-x64-gnu": "npm:1.1.3"
+    "@rolldown/binding-linux-x64-musl": "npm:1.1.3"
+    "@rolldown/binding-openharmony-arm64": "npm:1.1.3"
+    "@rolldown/binding-wasm32-wasi": "npm:1.1.3"
+    "@rolldown/binding-win32-arm64-msvc": "npm:1.1.3"
+    "@rolldown/binding-win32-x64-msvc": "npm:1.1.3"
     "@rolldown/pluginutils": "npm:^1.0.0"
   dependenciesMeta:
     "@rolldown/binding-android-arm64":
@@ -15654,7 +15684,7 @@ __metadata:
       optional: true
   bin:
     rolldown: ./bin/cli.mjs
-  checksum: 5f9dd47b7abf203b16bc600db68542f245e974c800e59ff50b76157d1dada1403657690435b036fabca88e93d13a67c31abe5cfaa6f61ce33717f61720204cdf
+  checksum: 6dae11bee45c56d000d5d2608ac78b2c7125b7f10337e0b0bbdee7290c352104f1f76072f8c0e6ccad331f51f1a131fc37faa179d9c4a10cc16abc87f85f6e86
   languageName: node
   linkType: hard
 
@@ -17553,19 +17583,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^8.0.16":
-  version: 8.0.16
-  resolution: "vite@npm:8.0.16"
+"vite@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "vite@npm:8.1.0"
   dependencies:
     fsevents: "npm:~2.3.3"
     lightningcss: "npm:^1.32.0"
     picomatch: "npm:^4.0.4"
     postcss: "npm:^8.5.15"
-    rolldown: "npm:1.0.3"
+    rolldown: "npm:~1.1.2"
     tinyglobby: "npm:^0.2.17"
   peerDependencies:
     "@types/node": ^20.19.0 || >=22.12.0
-    "@vitejs/devtools": ^0.1.18
+    "@vitejs/devtools": ^0.3.0
     esbuild: ^0.27.0 || ^0.28.0
     jiti: ">=1.21.0"
     less: ^4.0.0
@@ -17606,7 +17636,7 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: d75be3fbe2f63e6a8145325970338afaf0dd4d96ba9175c13f9a286fd5f95afc489401b693e4fa6c0899a4dd0e137be91cdf9401a40a635563911ad5036e3467
+  checksum: d7e2da70169a7d93c68f5d0e246bdf2fb35d8835170663a28f01191d73e16b80322b5f229973ce754de80136be843481b0afa616bb8530b51e7454e4887c4b45
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8797,9 +8797,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chromatic@npm:^17.5.0":
-  version: 17.5.0
-  resolution: "chromatic@npm:17.5.0"
+"chromatic@npm:^17.7.2":
+  version: 17.7.2
+  resolution: "chromatic@npm:17.7.2"
   dependencies:
     semver: "npm:^7.3.5"
   peerDependencies:
@@ -8817,7 +8817,7 @@ __metadata:
     chroma: dist/bin.cjs
     chromatic: dist/bin.cjs
     chromatic-cli: dist/bin.cjs
-  checksum: 38919ba7e45d2188d22699b086a48e20f6914c80b0f21ce0aa805c3e6052d618de63a1efeadc2fbf5d0debd878476e4e33ec867779255b0bc6a4c842f5e6a09d
+  checksum: 6fcbb27833a2abd775658e6f59d6325adb6b20baf8c108e961b39c81da222964fc1568d86d9eec8d703319e0eb9b0254b2cb815d8629410c147b1c6ff9b89351
   languageName: node
   linkType: hard
 
@@ -13509,7 +13509,7 @@ __metadata:
     "@vercel/speed-insights": "npm:2.0.0"
     babel-loader: "npm:^10.1.1"
     cheerio: "npm:^1.2.0"
-    chromatic: "npm:^17.5.0"
+    chromatic: "npm:^17.7.2"
     highlight.js: "npm:^11.11.1"
     husky: "npm:^9.1.7"
     hygen: "npm:^6.2.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6588,12 +6588,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^26.0.0":
-  version: 26.0.0
-  resolution: "@types/node@npm:26.0.0"
+"@types/node@npm:^26.0.1":
+  version: 26.0.1
+  resolution: "@types/node@npm:26.0.1"
   dependencies:
     undici-types: "npm:~8.3.0"
-  checksum: f36e21634fd8e8ded162ca486508bd8bb229d398a8d5541f6d8c1255968d4464e53327a77f403b216ef98e3b6f6956882eef83e4857d4bc2be9569dd55d37aae
+  checksum: 31d204333c70124da6bcac7d1f27d8980149fe3f95a8419bfcd19c3e5823705c0e370d71ac34399352e1263b2d5fc41c87af964ec81e5a05a32224d65d8d224e
   languageName: node
   linkType: hard
 
@@ -13500,7 +13500,7 @@ __metadata:
     "@tsparticles/engine": "npm:^3.9.1"
     "@tsparticles/react": "npm:^3.0.0"
     "@types/gtag.js": "npm:^0.0.20"
-    "@types/node": "npm:^26.0.0"
+    "@types/node": "npm:^26.0.1"
     "@types/react": "npm:^19.2.17"
     "@types/react-dom": "npm:^19.2.3"
     "@types/react-scroll": "npm:^1.8.10"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6861,11 +6861,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vercel/backends@npm:0.8.14":
-  version: 0.8.14
-  resolution: "@vercel/backends@npm:0.8.14"
+"@vercel/backends@npm:0.8.20":
+  version: 0.8.20
+  resolution: "@vercel/backends@npm:0.8.20"
   dependencies:
-    "@vercel/build-utils": "npm:13.30.0"
+    "@vercel/build-utils": "npm:13.32.2"
     "@vercel/nft": "npm:1.10.0"
     execa: "npm:3.2.0"
     fs-extra: "npm:11.1.0"
@@ -6874,10 +6874,10 @@ __metadata:
     path-to-regexp: "npm:8.3.0"
     resolve.exports: "npm:2.0.3"
     rolldown: "npm:1.0.0-rc.1"
-    srvx: "npm:0.8.9"
+    srvx: "npm:0.11.16"
     tsx: "npm:4.21.0"
     zod: "npm:3.22.4"
-  checksum: bb42cc83632964244aba70869dbf8d1a64f62c89de47980b222ec8e048353d23c6616f24225ce2b301ba3decdb6c8e959fdb2e26c41b715d02de236f07ad389e
+  checksum: db128ad362228c293a57db6478167e384e12e528f80b6dff5bc726a1cdf2d7eb0a9df6e290557fab2a412d53a6386de6f2536dbbc96a1cd8fd74661c00afe522
   languageName: node
   linkType: hard
 
@@ -6894,25 +6894,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vercel/build-utils@npm:13.30.0":
-  version: 13.30.0
-  resolution: "@vercel/build-utils@npm:13.30.0"
+"@vercel/build-utils@npm:13.32.2":
+  version: 13.32.2
+  resolution: "@vercel/build-utils@npm:13.32.2"
   dependencies:
     "@vercel/python-analysis": "npm:0.11.1"
     cjs-module-lexer: "npm:1.2.3"
     es-module-lexer: "npm:1.5.0"
-  checksum: 26e15da1cc086a75bf180fca6796810e4d368277ec61b2696efa7147efe9fb9a4f6082b8f793255a7c88d066b7867eafbc99481207327f3509831ea1b7064d8b
+  checksum: 58192ecd78fed4cac3d804d7ecc2c7ccda845ecdfa0dfa20c748ab39feccac5f10ef36b8d196f312bf2c766aedf335de3d3bab63d7d083c6457ed9c449e5611f
   languageName: node
   linkType: hard
 
-"@vercel/cervel@npm:0.1.22":
-  version: 0.1.22
-  resolution: "@vercel/cervel@npm:0.1.22"
+"@vercel/cervel@npm:0.1.28":
+  version: 0.1.28
+  resolution: "@vercel/cervel@npm:0.1.28"
   dependencies:
-    "@vercel/backends": "npm:0.8.14"
+    "@vercel/backends": "npm:0.8.20"
   bin:
     cervel: bin/cervel.mjs
-  checksum: 70c16140939b0215690c68ba74ce8654f843f34b97654b60a0bea1ab9f4843617f1a0feb5a47b06fd9c12375e3e893a7b389e19946730ae4eea77e75c683456e
+  checksum: a636cedf175e2a1f80a82070bfa51869f2737f6716a4d72b0f058fd956e138b184c8f564bf1153b12d992e9d808fa2e43e8abf9a1ae21c393e7ad6b72532ee1d
   languageName: node
   linkType: hard
 
@@ -6939,6 +6939,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vercel/container@npm:0.0.3":
+  version: 0.0.3
+  resolution: "@vercel/container@npm:0.0.3"
+  checksum: f657cba3db24b47919d93dfe3647a3adcaf7a0d8639281d1ab5d1f7d5982d941ceeac49397e11de5375e0c9317bf6501df87c88763cc8be4b2b8024bc2b73fff
+  languageName: node
+  linkType: hard
+
 "@vercel/detect-agent@npm:1.2.3":
   version: 1.2.3
   resolution: "@vercel/detect-agent@npm:1.2.3"
@@ -6946,13 +6953,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vercel/elysia@npm:0.1.93":
-  version: 0.1.93
-  resolution: "@vercel/elysia@npm:0.1.93"
+"@vercel/elysia@npm:0.1.98":
+  version: 0.1.98
+  resolution: "@vercel/elysia@npm:0.1.98"
   dependencies:
-    "@vercel/node": "npm:5.8.17"
+    "@vercel/node": "npm:5.8.22"
     "@vercel/static-config": "npm:3.4.0"
-  checksum: 33ff6bdd6dd695dddec9e9d3a6a957d590d065fb178eab64fcd5543186652d407d4e2f4101ad27f7511f66fdfa32575dd0b2d9a481ef2606999eee44c6320f39
+  checksum: ba48dc69ad6a093f3add3f43e239b1bc2edba229e9170cd37df605bd2470b0fa302f3f3846067a16785ef77bb9826f625adfc2f42080248ac99e0af2344dad89
   languageName: node
   linkType: hard
 
@@ -6963,29 +6970,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vercel/express@npm:0.1.105":
-  version: 0.1.105
-  resolution: "@vercel/express@npm:0.1.105"
+"@vercel/express@npm:0.1.111":
+  version: 0.1.111
+  resolution: "@vercel/express@npm:0.1.111"
   dependencies:
-    "@vercel/cervel": "npm:0.1.22"
+    "@vercel/cervel": "npm:0.1.28"
     "@vercel/nft": "npm:1.10.0"
-    "@vercel/node": "npm:5.8.17"
+    "@vercel/node": "npm:5.8.22"
     "@vercel/static-config": "npm:3.4.0"
     fs-extra: "npm:11.1.0"
     path-to-regexp: "npm:8.3.0"
     ts-morph: "npm:12.0.0"
     zod: "npm:3.22.4"
-  checksum: 0d22ba8f6f2066ae4b409dbab1cd059689fa04a5cb40a82c96c0b59819b4e373d36b87a9c14369dc506331e1ff4326e1aed86848de4a028e376a040424604cd6
+  checksum: 5c3befd1ea0aa1374a15c68033170b702a4e4ad425d5683a827c50c59ced076b85e9063ecf6f688898f14a7007a160ba5b61ac25ce8c35e9b6817c6a9e3e1dcd
   languageName: node
   linkType: hard
 
-"@vercel/fastify@npm:0.1.96":
-  version: 0.1.96
-  resolution: "@vercel/fastify@npm:0.1.96"
+"@vercel/fastify@npm:0.1.101":
+  version: 0.1.101
+  resolution: "@vercel/fastify@npm:0.1.101"
   dependencies:
-    "@vercel/node": "npm:5.8.17"
+    "@vercel/node": "npm:5.8.22"
     "@vercel/static-config": "npm:3.4.0"
-  checksum: 9f27efef4d17cde07f19d62ede0d40505b63f550f5678ce0ca389a3b7892c538c3a00b383d579a5ce6ac0038e1954b9b4944b1b6cd8568488f89f48e3b0fe008
+  checksum: dfc38a2848690514d3f027e5fa5097e3b38ad423668a60d34d107630a616d760a2785336c5a3ef6e4b63bf3fdbcf84192c642b9e937b7f7daf40d45cdba3d5db
   languageName: node
   linkType: hard
 
@@ -7024,48 +7031,48 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vercel/gatsby-plugin-vercel-builder@npm:2.2.19":
-  version: 2.2.19
-  resolution: "@vercel/gatsby-plugin-vercel-builder@npm:2.2.19"
+"@vercel/gatsby-plugin-vercel-builder@npm:2.2.24":
+  version: 2.2.24
+  resolution: "@vercel/gatsby-plugin-vercel-builder@npm:2.2.24"
   dependencies:
     "@sinclair/typebox": "npm:0.25.24"
-    "@vercel/build-utils": "npm:13.30.0"
+    "@vercel/build-utils": "npm:13.32.2"
     esbuild: "npm:0.27.0"
     etag: "npm:1.8.1"
     fs-extra: "npm:11.1.0"
-  checksum: cbf04dce556d957e915af443513da0424d5d9d41265c6e2cdc43bb1475041f335ab74aea6168950e142a82f1315a806e5d72b3d0300999ce3926ea38564859ac
+  checksum: 7ecf24da8df11b5bbf291e72768414b1edc8d39131b5e030e51a6a682a32b48f5a8d8be2eefb747afef92dd0d5022df800c4f5f26c5be6d6a2061c28d3c106e2
   languageName: node
   linkType: hard
 
-"@vercel/go@npm:3.9.1":
-  version: 3.9.1
-  resolution: "@vercel/go@npm:3.9.1"
-  checksum: 878f3dd9a2d2871e9f1b87c04c2e3dcdcee298959920390eaa16705068e1a7959280a101540241dc405d780fe1eee5748292c34865803e3be1e2f8b7d3a82091
+"@vercel/go@npm:3.10.2":
+  version: 3.10.2
+  resolution: "@vercel/go@npm:3.10.2"
+  checksum: af03e33ce8960072a7b04274c4f21bcb9c64028c384570ed2b51c3f261dac75d17a9b9f262669df71f059729369c955f35564f77960eae0b6a194f8e9023f39d
   languageName: node
   linkType: hard
 
-"@vercel/h3@npm:0.1.102":
-  version: 0.1.102
-  resolution: "@vercel/h3@npm:0.1.102"
+"@vercel/h3@npm:0.1.107":
+  version: 0.1.107
+  resolution: "@vercel/h3@npm:0.1.107"
   dependencies:
-    "@vercel/node": "npm:5.8.17"
+    "@vercel/node": "npm:5.8.22"
     "@vercel/static-config": "npm:3.4.0"
-  checksum: e46c90ff6a75d487eb01ff75178ad58c5d04b5b8a63b35bdaf000f3325e22af28eea4b4cc17efe50c6e69ed62b670565ad4d6048b185ea4ba65ca4f62e7a6a6d
+  checksum: b99c6cb0f086639436c279b78ccc14091dd25f8032f312002fb38be4332bc386e96b9e734eee1700ecfd59b800b15eac2df18e4ae03379b8c42c071872b111fd
   languageName: node
   linkType: hard
 
-"@vercel/hono@npm:0.2.96":
-  version: 0.2.96
-  resolution: "@vercel/hono@npm:0.2.96"
+"@vercel/hono@npm:0.2.101":
+  version: 0.2.101
+  resolution: "@vercel/hono@npm:0.2.101"
   dependencies:
     "@vercel/nft": "npm:1.10.0"
-    "@vercel/node": "npm:5.8.17"
+    "@vercel/node": "npm:5.8.22"
     "@vercel/static-config": "npm:3.4.0"
     fs-extra: "npm:11.1.0"
     path-to-regexp: "npm:8.3.0"
     ts-morph: "npm:12.0.0"
     zod: "npm:3.22.4"
-  checksum: 6cd587e83c7592b785b29987d30e795a82cba576fe81891dbdc4f73c9956132e538015c9f177a3cc12f9887f3b2f11e2b048fc2b683f0a93855f12881b530847
+  checksum: ae463811b98f20914f232d66a7648d8c556689d2ef463601246c671b96deead2d1756959c0015319b3634f1b1dbe75398a26063c29f73a5379c915ec471d98be
   languageName: node
   linkType: hard
 
@@ -7079,32 +7086,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vercel/koa@npm:0.1.76":
-  version: 0.1.76
-  resolution: "@vercel/koa@npm:0.1.76"
+"@vercel/koa@npm:0.1.81":
+  version: 0.1.81
+  resolution: "@vercel/koa@npm:0.1.81"
   dependencies:
-    "@vercel/node": "npm:5.8.17"
+    "@vercel/node": "npm:5.8.22"
     "@vercel/static-config": "npm:3.4.0"
-  checksum: 0b04681ecab1a22574a174e8bcc1c26c5ce10ddead474ac380068b84bd2fd955742953190f60828bef4e985e7426a37526314a734486097fe3a786d867fc690a
+  checksum: 6c203a198b27172bb9622fa3ec2c1e33cfd9761bc0626ddb90f11b80e91fd45cc93df71772e8bee14e2f8c050846b45b91406419713c0fa0a1ea8516bc7bf564
   languageName: node
   linkType: hard
 
-"@vercel/nestjs@npm:0.2.97":
-  version: 0.2.97
-  resolution: "@vercel/nestjs@npm:0.2.97"
+"@vercel/nestjs@npm:0.2.102":
+  version: 0.2.102
+  resolution: "@vercel/nestjs@npm:0.2.102"
   dependencies:
-    "@vercel/node": "npm:5.8.17"
+    "@vercel/node": "npm:5.8.22"
     "@vercel/static-config": "npm:3.4.0"
-  checksum: fb424554a5e2703ad9cddce2cbde43e2b9ef62b24a3f65c42c0219ae7c9d168d69b04b7f4f896f606ba647bc019ea98d3281d45a094a6c4ec418660841c96d99
+  checksum: 30f69d1b19e099731c2a83bd2e754be5bedc951b08beac534250023f5754c5eb36288e299b086bf81f60c8447ae8f7512412be9283e0088362d874e2f7099ab5
   languageName: node
   linkType: hard
 
-"@vercel/next@npm:4.19.1":
-  version: 4.19.1
-  resolution: "@vercel/next@npm:4.19.1"
+"@vercel/next@npm:4.20.1":
+  version: 4.20.1
+  resolution: "@vercel/next@npm:4.20.1"
   dependencies:
     "@vercel/nft": "npm:1.10.0"
-  checksum: eb416e94b6c4060feb54762af8631de946d4782bf989840f67ae4b284cdd183278ac6849496a172ea88c399bb345e142fc7270d6c26ed9b8750f0f0f6a15867f
+  checksum: 714b16fe64f54cf9fbae3a98a04ff34224a9eea97c78d3b416094e5b10c350577025a15ceb574de4b6bdb147bea31dc43497de2f06c2dc2ba80e8f5865bbd99f
   languageName: node
   linkType: hard
 
@@ -7130,15 +7137,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vercel/node@npm:5.8.17":
-  version: 5.8.17
-  resolution: "@vercel/node@npm:5.8.17"
+"@vercel/node@npm:5.8.22":
+  version: 5.8.22
+  resolution: "@vercel/node@npm:5.8.22"
   dependencies:
     "@edge-runtime/node-utils": "npm:2.3.0"
     "@edge-runtime/primitives": "npm:4.1.0"
     "@edge-runtime/vm": "npm:3.2.0"
     "@types/node": "npm:20.11.0"
-    "@vercel/build-utils": "npm:13.30.0"
+    "@vercel/build-utils": "npm:13.32.2"
     "@vercel/error-utils": "npm:2.2.0"
     "@vercel/nft": "npm:1.10.0"
     "@vercel/static-config": "npm:3.4.0"
@@ -7156,7 +7163,7 @@ __metadata:
     tsx: "npm:4.21.0"
     typescript: "npm:typescript@5.9.3"
     undici: "npm:5.28.4"
-  checksum: c4064ad530a4d29c2554ac10d5d80a37f092bea2c210cac86337e165c421e54fd371e5beeeb29c2451905e0fc4e49eb446c0be3db1e429aa1e66b0eac7ee08fe
+  checksum: ce6f953c0c222f09d4e441a314849748263c2834f52b87bfc3f121d7ccca8881885260c3b29028e21d1c538f2a1bb0c2f765b7e8ff08abde6eb40ec6922aa258
   languageName: node
   linkType: hard
 
@@ -7189,12 +7196,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vercel/python@npm:6.47.0":
-  version: 6.47.0
-  resolution: "@vercel/python@npm:6.47.0"
+"@vercel/python@npm:6.47.3":
+  version: 6.47.3
+  resolution: "@vercel/python@npm:6.47.3"
   dependencies:
     "@vercel/python-analysis": "npm:0.11.1"
-  checksum: 6486465bdda81122082ef21fe6b84300e0953c948c7c7a474115331b4d48088b7f6a5bf76d7b90d2b49b5e7ae80e8951542700ac903123914875198303c48524
+  checksum: b4125ac5b1d3ef44ab7ced97b790849e7b5c94278d01a085ebb741e2bbabb17958e72a3b740b4613a8b222684076a6ed6e35c11b6a2560c4289c483b582c1596
   languageName: node
   linkType: hard
 
@@ -7224,10 +7231,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vercel/ruby@npm:2.4.0":
-  version: 2.4.0
-  resolution: "@vercel/ruby@npm:2.4.0"
-  checksum: 96e970bb8442a19af36fc606c3f03d5fbcd27f9fe3da0ce58ec4354e3317cb0b0431d4c093f814b8bd4001711d1bfb5faefac9564f62c0163666a5b02d0c9b2a
+"@vercel/ruby@npm:2.5.1":
+  version: 2.5.1
+  resolution: "@vercel/ruby@npm:2.5.1"
+  checksum: b8bf29db118f07416af1550c3a1d22b97aa0eb07c812236c0a44552de59dfd4a52fc59dc2cd92066df2decd2708085402f310f30b660ca5b9314f1383f44d2b3
   languageName: node
   linkType: hard
 
@@ -7290,15 +7297,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vercel/static-build@npm:2.10.3":
-  version: 2.10.3
-  resolution: "@vercel/static-build@npm:2.10.3"
+"@vercel/static-build@npm:2.11.4":
+  version: 2.11.4
+  resolution: "@vercel/static-build@npm:2.11.4"
   dependencies:
     "@vercel/gatsby-plugin-vercel-analytics": "npm:1.0.11"
-    "@vercel/gatsby-plugin-vercel-builder": "npm:2.2.19"
+    "@vercel/gatsby-plugin-vercel-builder": "npm:2.2.24"
     "@vercel/static-config": "npm:3.4.0"
     ts-morph: "npm:12.0.0"
-  checksum: 28fbc92fde306714d1afc3ba5c0d50286c81eaf4adbdd246968974a012f18dfc02cc9fc47a0556c4a65343aeb24bdfc9f28bb17345549bf0d278aed7eb4a2f20
+  checksum: 5c0dd1c45c7d4930ed3dd7062b5b186770cbc9b3b84431c9c22611c0bb1adb6926e9fe647864f93c0a6777dc9377cdbac4aae019ec519350062220fb0cb2dd1e
   languageName: node
   linkType: hard
 
@@ -7956,13 +7963,6 @@ __metadata:
   version: 3.2.5
   resolution: "async@npm:3.2.5"
   checksum: 1408287b26c6db67d45cb346e34892cee555b8b59e6c68e6f8c3e495cad5ca13b4f218180e871f3c2ca30df4ab52693b66f2f6ff43644760cab0b2198bda79c1
-  languageName: node
-  linkType: hard
-
-"asynckit@npm:^0.4.0":
-  version: 0.4.0
-  resolution: "asynckit@npm:0.4.0"
-  checksum: d73e2ddf20c4eb9337e1b3df1a0f6159481050a5de457c55b14ea2e5cb6d90bb69e004c9af54737a5ee0917fcf2c9e25de67777bbe58261847846066ba75bc9d
   languageName: node
   linkType: hard
 
@@ -8996,15 +8996,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"combined-stream@npm:^1.0.8":
-  version: 1.0.8
-  resolution: "combined-stream@npm:1.0.8"
-  dependencies:
-    delayed-stream: "npm:~1.0.0"
-  checksum: 0dbb829577e1b1e839fa82b40c07ffaf7de8a09b935cadd355a73652ae70a88b4320db322f6634a4ad93424292fa80973ac6480986247f1734a1137debf271d5
-  languageName: node
-  linkType: hard
-
 "commander@npm:^2.20.0":
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
@@ -9096,13 +9087,6 @@ __metadata:
   version: 2.0.0
   resolution: "convert-source-map@npm:2.0.0"
   checksum: 8f2f7a27a1a011cc6cc88cc4da2d7d0cfa5ee0369508baae3d98c260bb3ac520691464e5bbe4ae7cdf09860c1d69ecc6f70c63c6e7c7f7e3f18ec08484dc7d9b
-  languageName: node
-  linkType: hard
-
-"cookie-es@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "cookie-es@npm:2.0.0"
-  checksum: 3b2459030a5ad2bc715aeb27a32f274340670bfc5031ac29e1fba804212517411bb617880d3fe66ace2b64dfb28f3049e2d1ff40d4bec342154ccdd124deaeaa
   languageName: node
   linkType: hard
 
@@ -9530,13 +9514,6 @@ __metadata:
   bin:
     degit: degit
   checksum: 25ae9daf8010b450ffe8307c5ca903fe8bfaa8bb8622da12f81f2b6c3b1bb24e96fe3ab0b4ec4a1a19684f674b2158a8a3a2178c481882cc4991c7a0859ec40a
-  languageName: node
-  linkType: hard
-
-"delayed-stream@npm:~1.0.0":
-  version: 1.0.0
-  resolution: "delayed-stream@npm:1.0.0"
-  checksum: d758899da03392e6712f042bec80aa293bbe9e9ff1b2634baae6a360113e708b91326594c8a486d475c69d6259afb7efacdc3537bfcda1c6c648e390ce601b19
   languageName: node
   linkType: hard
 
@@ -10073,18 +10050,6 @@ __metadata:
   dependencies:
     es-errors: "npm:^1.3.0"
   checksum: 65364812ca4daf48eb76e2a3b7a89b3f6a2e62a1c420766ce9f692665a29d94fe41fe88b65f24106f449859549711e4b40d9fb8002d862dfd7eb1c512d10be0c
-  languageName: node
-  linkType: hard
-
-"es-set-tostringtag@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "es-set-tostringtag@npm:2.1.0"
-  dependencies:
-    es-errors: "npm:^1.3.0"
-    get-intrinsic: "npm:^1.2.6"
-    has-tostringtag: "npm:^1.0.2"
-    hasown: "npm:^2.0.2"
-  checksum: ef2ca9ce49afe3931cb32e35da4dcb6d86ab02592cfc2ce3e49ced199d9d0bb5085fc7e73e06312213765f5efa47cc1df553a6a5154584b21448e9fb8355b1af
   languageName: node
   linkType: hard
 
@@ -10799,19 +10764,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"form-data@npm:^4.0.0":
-  version: 4.0.6
-  resolution: "form-data@npm:4.0.6"
-  dependencies:
-    asynckit: "npm:^0.4.0"
-    combined-stream: "npm:^1.0.8"
-    es-set-tostringtag: "npm:^2.1.0"
-    hasown: "npm:^2.0.4"
-    mime-types: "npm:^2.1.35"
-  checksum: 43947a77bf0ff45c6ceed789778982d47a3f3e720a74b71721174ebf3310a5f1a8be1d6b38a3ee3688e8a18a2c4273073ec0844cd37efda3eaf46d41c9c318ff
-  languageName: node
-  linkType: hard
-
 "fp-ts@npm:^2.9.2":
   version: 2.16.1
   resolution: "fp-ts@npm:2.16.1"
@@ -11288,15 +11240,6 @@ __metadata:
   dependencies:
     function-bind: "npm:^1.1.2"
   checksum: 3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
-  languageName: node
-  linkType: hard
-
-"hasown@npm:^2.0.4":
-  version: 2.0.4
-  resolution: "hasown@npm:2.0.4"
-  dependencies:
-    function-bind: "npm:^1.1.2"
-  checksum: 2d8de939e270b70618f8cebb69746620db10617dbb495bc66ddad326955ea24d3ca4af133aff3eb7c1853e0218f867bc2b050ec26fe02e3aea58f880ffc5e506
   languageName: node
   linkType: hard
 
@@ -13282,7 +13225,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-types@npm:2.1.35, mime-types@npm:^2.1.27, mime-types@npm:^2.1.31, mime-types@npm:^2.1.35":
+"mime-types@npm:2.1.35, mime-types@npm:^2.1.27, mime-types@npm:^2.1.31":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:
@@ -13531,7 +13474,7 @@ __metadata:
     tsconfig-paths-webpack-plugin: "npm:^4.2.0"
     tsparticles: "npm:^3.9.1"
     typescript: "npm:^6.0.3"
-    vercel: "npm:^54.14.5"
+    vercel: "npm:^54.18.2"
     vite: "npm:^8.0.16"
   languageName: unknown
   linkType: soft
@@ -16297,14 +16240,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"srvx@npm:0.8.9":
-  version: 0.8.9
-  resolution: "srvx@npm:0.8.9"
-  dependencies:
-    cookie-es: "npm:^2.0.0"
+"srvx@npm:0.11.16":
+  version: 0.11.16
+  resolution: "srvx@npm:0.11.16"
   bin:
     srvx: bin/srvx.mjs
-  checksum: c969252eebd3f1f1def2e6ff1d17cfb61eb37fc9d7c0ff5636c705a563dc05a2ae4fdf0dd8c8094321818975fe216ffca0db8b5c0322c61627d8a5e3da03a3b0
+  checksum: cd3ed12c12481e2852409a7dfaa8c1ae0a7264769e9239e4a34da48033029c2ce4b2bccfd648a49f9bb10d13c4be91fcdbdb50feb08bf3de19bc8cfe71efa0a2
   languageName: node
   linkType: hard
 
@@ -17270,6 +17211,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici@npm:5.29.0":
+  version: 5.29.0
+  resolution: "undici@npm:5.29.0"
+  dependencies:
+    "@fastify/busboy": "npm:^2.0.0"
+  checksum: e4e4d631ca54ee0ad82d2e90e7798fa00a106e27e6c880687e445cc2f13b4bc87c5eba2a88c266c3eecffb18f26e227b778412da74a23acc374fca7caccec49b
+  languageName: node
+  linkType: hard
+
 "undici@npm:^6.23.0":
   version: 6.23.0
   resolution: "undici@npm:6.23.0"
@@ -17557,48 +17507,49 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vercel@npm:^54.14.5":
-  version: 54.14.5
-  resolution: "vercel@npm:54.14.5"
+"vercel@npm:^54.18.2":
+  version: 54.18.2
+  resolution: "vercel@npm:54.18.2"
   dependencies:
-    "@vercel/backends": "npm:0.8.14"
+    "@vercel/backends": "npm:0.8.20"
     "@vercel/blob": "npm:2.4.0"
-    "@vercel/build-utils": "npm:13.30.0"
+    "@vercel/build-utils": "npm:13.32.2"
     "@vercel/cli-auth": "npm:0.3.0"
     "@vercel/cli-config": "npm:0.2.0"
+    "@vercel/container": "npm:0.0.3"
     "@vercel/detect-agent": "npm:1.2.3"
-    "@vercel/elysia": "npm:0.1.93"
-    "@vercel/express": "npm:0.1.105"
-    "@vercel/fastify": "npm:0.1.96"
+    "@vercel/elysia": "npm:0.1.98"
+    "@vercel/express": "npm:0.1.111"
+    "@vercel/fastify": "npm:0.1.101"
     "@vercel/fun": "npm:1.3.0"
-    "@vercel/go": "npm:3.9.1"
-    "@vercel/h3": "npm:0.1.102"
-    "@vercel/hono": "npm:0.2.96"
+    "@vercel/go": "npm:3.10.2"
+    "@vercel/h3": "npm:0.1.107"
+    "@vercel/hono": "npm:0.2.101"
     "@vercel/hydrogen": "npm:1.4.0"
-    "@vercel/koa": "npm:0.1.76"
-    "@vercel/nestjs": "npm:0.2.97"
-    "@vercel/next": "npm:4.19.1"
-    "@vercel/node": "npm:5.8.17"
+    "@vercel/koa": "npm:0.1.81"
+    "@vercel/nestjs": "npm:0.2.102"
+    "@vercel/next": "npm:4.20.1"
+    "@vercel/node": "npm:5.8.22"
     "@vercel/prepare-flags-definitions": "npm:0.3.0"
-    "@vercel/python": "npm:6.47.0"
+    "@vercel/python": "npm:6.47.3"
     "@vercel/redwood": "npm:2.5.0"
     "@vercel/remix-builder": "npm:5.9.1"
-    "@vercel/ruby": "npm:2.4.0"
+    "@vercel/ruby": "npm:2.5.1"
     "@vercel/rust": "npm:1.3.0"
-    "@vercel/static-build": "npm:2.10.3"
+    "@vercel/static-build": "npm:2.11.4"
     chokidar: "npm:4.0.0"
     esbuild: "npm:0.27.0"
-    form-data: "npm:^4.0.0"
     jose: "npm:5.9.6"
     luxon: "npm:^3.4.0"
     proxy-agent: "npm:6.4.0"
     sandbox: "npm:3.1.2"
     smol-toml: "npm:1.5.2"
+    undici: "npm:5.29.0"
     zod: "npm:4.1.11"
   bin:
     vc: dist/vc.js
     vercel: dist/vc.js
-  checksum: edab5730fd2288a4317d5b63f33f9e1992d8a0b0bac96e559a7dd8fe90b8c0d605051ca5d1f5711a2fc540977676b00994761ff5837d7e4f3f15d1dec0a43321
+  checksum: 9f6b442383a2bf77c229aa53d605e32daf89710785ed6d10e94819bec4b61826073c6e4fceb90bc2c84d377dd2453d050710b016f66b300609e8575ca0b59588
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Weekly automated package upgrades for 2026-06-28.

## Upgraded Packages

| Package | Old Version | New Version |
|---------|-------------|-------------|
| `@types/node` | 26.0.0 | 26.0.1 |
| `chromatic` | 17.5.0 | 17.7.2 |
| `vercel` | 54.14.5 | 54.18.2 |
| `vite` | 8.0.16 | 8.1.0 |

## Verification

All upgrades passed:
- ✅ `yarn check` — no errors (6 warnings, 3 infos, pre-existing)
- ✅ `yarn build` — successful Next.js build

## Skipped Packages

The following packages were skipped due to known breaking changes (tracked in cache memory):

| Package | Current | Latest | Reason |
|---------|---------|--------|--------|
| `@tsparticles/all` | 3.9.1 | 4.x | v4 breaking changes: `initParticlesEngine` removed from `@tsparticles/react`; requires source changes to `Particle.tsx` |
| `@tsparticles/engine` | 3.9.1 | 4.x | Part of tsparticles ecosystem — blocked by above |
| `@tsparticles/react` | 3.0.0 | 4.x | v4 removed `initParticlesEngine` export |
| `tsparticles` | 3.9.1 | 4.x | Part of tsparticles ecosystem — blocked by above |




> Generated by [📦 Weekly Package Upgrade Agent](https://github.com/WakuwakuP/miyulab-officialsite/actions/runs/28337744554)
> - [x] expires <!-- gh-aw-expires: 2026-07-05T22:21:06.700Z --> on Jul 5, 2026, 10:21 PM UTC

<!-- gh-aw-agentic-workflow: 📦 Weekly Package Upgrade Agent, engine: copilot, id: 28337744554, workflow_id: weekly-package-upgrade, run: https://github.com/WakuwakuP/miyulab-officialsite/actions/runs/28337744554 -->

<!-- gh-aw-expires-type: pull-request -->

<!-- gh-aw-workflow-id: weekly-package-upgrade -->